### PR TITLE
update readme links for pypi

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 
   <a href="https://github.com/emdgroup/foundry-dev-tools/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/emdgroup/foundry-dev-tools/ci.yml?style=flat-square"/></img>
   <a href="https://github.com/emdgroup/foundry-dev-tools/actions/workflows/docs.yml"><img src="https://img.shields.io/github/actions/workflow/status/emdgroup/foundry-dev-tools/docs.yml?style=flat-square"/></img>
+  <a href="ihttps://pypi.org/project/foundry-dev-tools/"><img src="https://img.shields.io/pypi/v/foundry-dev-tools.svg"/></a>
   <a href="http://www.apache.org/licenses/LICENSE-2.0"><img src="https://shields.io/badge/License-Apache%202.0-green.svg?style=flat-square"/></a>
   <a href="https://github.com/emdgroup/foundry-dev-tools/issues"><img src="https://img.shields.io/github/issues/emdgroup/foundry-dev-tools?color=important&style=flat-square"/></a>
   <a href="https://github.com/emdgroup/foundry-dev-tools/pulls"><img src="https://img.shields.io/github/issues-pr/emdgroup/foundry-dev-tools?color=blueviolet&style=flat-square"/></a>
@@ -15,7 +16,7 @@
 
   <a href="https://emdgroup.github.io/foundry-dev-tools/installation.html">Installation<a/>
   &nbsp;•&nbsp;
-  <a href="https://emdgroup.github.io/foundry-dev-tools/usage.html">Usage<a/>
+  <a href="https://emdgroup.github.io/foundry-dev-tools/usage_and_examples.html">Usage<a/>
   &nbsp;•&nbsp;
   <a href="https://emdgroup.github.io/foundry-dev-tools/develop.html">Development<a/>
 
@@ -27,11 +28,11 @@ Seamlessly run your Palantir Foundry Repository transforms code and more on your
 Foundry DevTools is a set of useful libraries to interact with the Foundry APIs. There are currently three
 high level entrypoints to Foundry DevTools:
 
-* [FoundryRestClient](docs/FoundryRestClient_usage.md)
+* [FoundryRestClient](https://emdgroup.github.io/foundry-dev-tools/FoundryRestClient_usage.html)
 
   * An API client that contains an opinionated client implementation to some of Foundry's APIs.
 
-* [FoundryFileSystem](docs/FoundryFileSystem_usage.md)
+* [FoundryFileSystem](https://emdgroup.github.io/foundry-dev-tools/FoundryFileSystem_usage.html)
 
   * An implementation of `fsspec` for Foundry. Useful to interact with Foundry from popular data science libraries such as
   `pandas` or `dask`.
@@ -74,4 +75,4 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
-The full text of the license can be found in the file [LICENSE](LICENSE) in the repository root directory.
+The full text of the license can be found in the file [LICENSE](https://github.com/emdgroup/foundry-dev-tools/blob/main/LICENSE) in the repository root directory.

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,10 @@ classifiers =
     Development Status :: 5 - Production/Stable
     Programming Language :: Python
     License :: OSI Approved :: Apache Software License
-
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
 
 [options]
 zip_safe = False
@@ -34,7 +37,6 @@ package_dir =
     =src
 # Add here dependencies of your project (semicolon/line-separated), e.g.
 install_requires =
-    importlib-metadata; python_version<"3.8"
     pyarrow
     pandas
     requests


### PR DESCRIPTION
# Summary

the links in the readme were previously relative
as pypi can't use relative links,
these links are now absolute URLs to the docs.

Also added supported version classifiers to the setup.cfg


# Checklist

- [x] You agree with our [CLA](https://gist.githubusercontent.com/emdgroup-admin/16cc45ea4315c2ef29eb9d9afc36fcf5/raw/abb9c91f15278a62b9ac3e66144bcd27fa9485c2/CLA.md)
- [x] Included tests (or is not applicable).
- [x] Updated [documentation](https://emdgroup.github.io/foundry-dev-tools/) (or is not applicable).
- [x] Used [pre-commit hooks](https://emdgroup.github.io/foundry-dev-tools/develop.html#pre-commit-hooks-formatting) to format and lint the code.
