### PR TITLE
refactor changelog and minor changes in setup.cfg

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ Seamlessly run your Palantir Foundry Repository transforms code and more on your
 Foundry DevTools is a set of useful libraries to interact with the Foundry APIs. There are currently three
 high level entrypoints to Foundry DevTools:
 
+* A [transforms](https://www.palantir.com/docs/foundry/transforms-python/transforms-python-api/) implementation
+
+  * An implementation of the Foundry `transforms` package that internally uses the `CachedFoundryClient`.
+    This allows you to seamlessly run your Palantir Foundry Code Repository transforms code on your local machine.
+    Foundry DevTools does not cover all of Foundry's features, more on this [here](https://emdgroup.github.io/foundry-dev-tools/architecture.html#known-limitations).
+
 * [FoundryRestClient](https://emdgroup.github.io/foundry-dev-tools/FoundryRestClient_usage.html)
 
   * An API client that contains an opinionated client implementation to some of Foundry's APIs.
@@ -36,8 +42,9 @@ high level entrypoints to Foundry DevTools:
 
     # Queries the Foundry SQL Server with spark SQL dialect
     rest_client = FoundryRestClient()
-    df = rest_client.query_foundry_sql("SELECT * FROM `/path/to/test_dataset`", branch='master')
-    df.to_string()
+    df = rest_client.query_foundry_sql("SELECT * FROM `/Global/Foundry Training and Resources/Foundry Reference Project/Ontology Project: Aviation/airlines`", branch='master')
+    df.shape
+    # Out[2]: (17, 10)
     ```
 
 * [FoundryFileSystem](https://emdgroup.github.io/foundry-dev-tools/FoundryFileSystem_usage.html)
@@ -52,14 +59,9 @@ high level entrypoints to Foundry DevTools:
     # /Global/Foundry Training and Resources/Foundry Reference Project/Ontology Project: Aviation/airlines
     df = pd.read_parquet("foundry://ri.foundry.main.dataset.5d78f3ae-a588-4fd8-9ba2-66827808c85f")
     df.shape
-    Out[2]: (17, 10)
+    # Out[2]: (17, 10)
     ```
 
-* A [transforms](https://www.palantir.com/docs/foundry/transforms-python/transforms-python-api/) implementation
-
-  * An implementation of the Foundry `transforms` package that internally uses the `CachedFoundryClient`.
-    This allows you to seamlessly run your Palantir Foundry Code Repository transforms code on your local machine.
-    Foundry DevTools does not cover all of Foundry's features, more on this [here](https://emdgroup.github.io/foundry-dev-tools/architecture.html#known-limitations).
 
 ## Quickstart
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,11 +1,51 @@
 # Changelog
 
-## Version 1.0.2 (2023-02-28)
-Minor documentation and README changes
+All notable changes to this project will be documented in this file.
 
-## Version 1.0.1 (2023-02-28)
-Added pypi shield to readme and fixxed relative links.
-Added version classifiers to the setup.cfg
+The format is based on [Keep a Changelog],
+and this project adheres to [Semantic Versioning].
 
-## Version 1.0 (2023-02-28)
-First public Open Source Release of Foundry DevTools.
+## [1.0.3] - 2023-03-07
+
+### Added
+
+- tracker and changelog url to setup.cfg (#4)
+- more pypi classifiers to setup.cfg (#4)
+
+### Changed
+
+- Changelog is now in the format of [Keep a Changelog] (#4)
+- Updated fsspec example in README (#3)
+
+### Fixed
+
+- README code block highlighting and Apache License link (#2)
+- wrong styling of pipy batch in readme (#1)
+
+## [1.0.2] - 2023-02-28
+
+### Changed
+
+- Minor documentation and README changes
+
+## [1.0.1] - 2023-02-28 [YANKED]
+
+### Added
+
+- pypi shield to readme
+- version classifiers to the setup.cfg
+
+### Fixed
+
+- relative links in readme
+
+## [1.0] - 2023-02-28 [YANKED]
+
+- First public Open Source Release of Foundry DevTools.
+
+[Keep a Changelog]: https://keepachangelog.com/en/1.0.0/
+[Semantic Versioning]: https://semver.org/spec/v2.0.0.html
+[1.0.3]: https://github.com/emdgroup/foundry-dev-tools/compare/v1.0.2...v1.0.3
+[1.0.2]: https://github.com/emdgroup/foundry-dev-tools/releases/tag/v1.0.2
+[1.0.1]: https://github.com/emdgroup/foundry-dev-tools
+[1.0]: https://github.com/emdgroup/foundry-dev-tools

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,3 @@
-# This file is used to configure your project.
-# Read more about the various options under:
-# http://setuptools.readthedocs.io/en/latest/setuptools.html#configuring-setup-using-setup-cfg-files
-
 [metadata]
 name = foundry-dev-tools
 description = Seamlessly run your Palantir Foundry Repository transforms code on your local machine.
@@ -16,7 +12,8 @@ url = https://github.com/emdgroup/foundry-dev-tools
 project_urls =
     Documentation = https://emdgroup.github.io/foundry-dev-tools
     Source = https://github.com/emdgroup/foundry-dev-tools
-# Change if running only on Windows, Mac or Linux (comma-separated)
+    Tracker = https://github.com/emdgroup/foundry-dev-tools/issues
+    Changelog = https://emdgroup.github.io/foundry-dev-tools/changelog.html
 platforms = any
 # Add here all kinds of additional classifiers as defined under
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers
@@ -28,6 +25,11 @@ classifiers =
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Intended Audience :: Developers
+    Operating System :: POSIX :: Linux
+    Operating System :: MacOS
+    Operating System :: Microsoft :: Windows
+    Topic :: Scientific/Engineering :: Information Analysis
 
 [options]
 zip_safe = False
@@ -35,7 +37,6 @@ packages = find_namespace:
 include_package_data = True
 package_dir =
     =src
-# Add here dependencies of your project (semicolon/line-separated), e.g.
 install_requires =
     pyarrow
     pandas
@@ -43,9 +44,6 @@ install_requires =
     fs
     backoff
     palantir-oauth-client
-# The usage of test_requires is discouraged, see `Dependency Management` docs
-# tests_require = pytest; pytest-cov
-# Require a specific Python version, e.g. Python 2.7 or >= 3.4
 python_requires = >=3.8,<4.0
 
 [options.packages.find]
@@ -77,15 +75,9 @@ fsspec.specs =
     foundry = foundry_dev_tools.fsspec_impl.FoundryFileSystem
 
 [test]
-# py.test options when running `python setup.py test`
-# addopts = --verbose
 extras = True
 
 [tool:pytest]
-# Options for py.test:
-# Specify command line options as you would do when invoking py.test directly.
-# e.g. --cov-report html (or xml) for html/xml output or --junitxml junit.xml
-# in order to write a coverage file that can be read by Jenkins.
 addopts =
     --cov=src --cov-report term --cov-report xml:coverage.xml --cov-report html:htmlcov
     --verbose
@@ -110,7 +102,6 @@ no-vcs = 1
 formats = bdist_wheel
 
 [flake8]
-# Some sane defaults for the code style checker flake8
 exclude =
     .tox
     build


### PR DESCRIPTION
# Summary

- changelog is now in the format of [Keep a Changelog](https://keepachangelog.com/)
- added tracker and changelog url to setup.cfg
- added more pypi classifiers to setup.cfg
- reordered README examples

# Checklist

- [x] You agree with our [CLA](https://gist.githubusercontent.com/emdgroup-admin/16cc45ea4315c2ef29eb9d9afc36fcf5/raw/abb9c91f15278a62b9ac3e66144bcd27fa9485c2/CLA.md)
- [x] Included tests (or is not applicable).
- [x] Updated [documentation](https://emdgroup.github.io/foundry-dev-tools/) (or is not applicable).
- [x] Used [pre-commit hooks](https://emdgroup.github.io/foundry-dev-tools/develop.html#pre-commit-hooks-formatting) to format and lint the code.
