### PR TITLE
Do not throw exception when git installation is missing

### DIFF
--- a/src/foundry_dev_tools/config.py
+++ b/src/foundry_dev_tools/config.py
@@ -367,4 +367,7 @@ def _find_project_config_file(project_directory: Path) -> str:
         raise ValueError()
     # FileNotFoundError is thrown when git is not installed
     except (subprocess.CalledProcessError, FileNotFoundError) as exc:
+        warnings.warn(
+            "Could not find top-level directory of project, is git not installed?"
+        )
         raise ValueError from exc

--- a/src/foundry_dev_tools/config.py
+++ b/src/foundry_dev_tools/config.py
@@ -365,5 +365,6 @@ def _find_project_config_file(project_directory: Path) -> str:
                 )
                 return foundry_local_project_config_file
         raise ValueError()
-    except subprocess.CalledProcessError as exc:
+    # FileNotFoundError is thrown when git is not installed
+    except (subprocess.CalledProcessError, FileNotFoundError) as exc:
         raise ValueError from exc

--- a/src/foundry_dev_tools/config.py
+++ b/src/foundry_dev_tools/config.py
@@ -365,9 +365,13 @@ def _find_project_config_file(project_directory: Path) -> str:
                 )
                 return foundry_local_project_config_file
         raise ValueError()
-    # FileNotFoundError is thrown when git is not installed
-    except (subprocess.CalledProcessError, FileNotFoundError) as exc:
-        warnings.warn(
-            "Could not find top-level directory of project, is git not installed?"
+    except FileNotFoundError as exc:
+        LOGGER.debug(
+            "Project-based config file could not be loaded due to missing git installation"
+        )
+        raise ValueError from exc
+    except subprocess.CalledProcessError as exc:
+        LOGGER.debug(
+            "Project-based config file could not be loaded, is project not managed with git?"
         )
         raise ValueError from exc


### PR DESCRIPTION
# Summary

When git is not installed the import of foundry_dev_tools fails with the stack trace below. As the stacktrace shows, the  issue is that foundry_dev_tools uses the git cli to try to find a .foundry_dev_tools folder in the project root directory.
This bugfix follows the approach in transforms.api._dataset._get_branch and also catches the FileNotFoundError.

```shell
  File "/opt/conda/lib/python3.10/site-packages/foundry_dev_tools/__init__.py", line 9, in <module>
    ) = foundry_dev_tools.config.initial_config()
  File "/opt/conda/lib/python3.10/site-packages/foundry_dev_tools/config.py", line 152, in initial_config
    project_config_file = _find_project_config_file(
  File "/opt/conda/lib/python3.10/site-packages/foundry_dev_tools/config.py", line 349, in _find_project_config_file
    git_directory = _traverse_to_git_project_top_level_dir(project_directory)
  File "/opt/conda/lib/python3.10/site-packages/foundry_dev_tools/config.py", line 326, in _traverse_to_git_project_top_level_dir
    return execute_as_subprocess(["git", "rev-parse", "--show-toplevel"], git_dir)
  File "/opt/conda/lib/python3.10/site-packages/foundry_dev_tools/config.py", line 341, in execute_as_subprocess
    return subprocess.run(
  File "/opt/conda/lib/python3.10/subprocess.py", line 503, in run
    with Popen(*popenargs, **kwargs) as process:
  File "/opt/conda/lib/python3.10/subprocess.py", line 971, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "/opt/conda/lib/python3.10/subprocess.py", line 1847, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
FileNotFoundError: [Errno 2] No such file or directory: 'git'
```

# Checklist

- [x] You agree with our [CLA](https://gist.githubusercontent.com/emdgroup-admin/16cc45ea4315c2ef29eb9d9afc36fcf5/raw/abb9c91f15278a62b9ac3e66144bcd27fa9485c2/CLA.md)
- [ ] Included tests (or is not applicable).
- [x] Updated [documentation](https://emdgroup.github.io/foundry-dev-tools/) (or is not applicable).
- [x] Used [pre-commit hooks](https://emdgroup.github.io/foundry-dev-tools/develop.html#pre-commit-hooks-formatting) to format and lint the code.
