### PR TITLE
Use gatekeeper:view-resource over compass:view

### DIFF
--- a/src/foundry_dev_tools/foundry_api_client.py
+++ b/src/foundry_dev_tools/foundry_api_client.py
@@ -915,7 +915,7 @@ class FoundryRestClient:
             dataset_path_or_rid (str): Path to dataset (e.g. /Global/...)
                 or rid of dataset (e.g. ri.foundry.main.dataset...)
             branch (str): branch of the dataset
-            check_read_access (bool): default is True, checks if the user has read access ('compass:read-resource')
+            check_read_access (bool): default is True, checks if the user has read access ('gatekeeper:view-resource')
                 to the dataset otherwise exception is thrown
 
         Returns:
@@ -930,7 +930,7 @@ class FoundryRestClient:
         dataset_rid = dataset_details["rid"]
         dataset_path = dataset_details["path"]
         if check_read_access:
-            if "compass:read-resource" not in dataset_details["operations"]:
+            if "gatekeeper:view-resource" not in dataset_details["operations"]:
                 raise DatasetNoReadAccessError(dataset_rid)
         return {
             "dataset_path": dataset_path,
@@ -2318,7 +2318,7 @@ class DatasetHasNoTransactionsError(FoundryAPIError):
 
 
 class DatasetNoReadAccessError(FoundryAPIError):
-    """Exception is thrown when user is missing 'compass:read-resource' on the dataset,
+    """Exception is thrown when user is missing 'gatekeeper:view-resource' on the dataset,
     which normally comes with the Viewer role."""
 
     def __init__(self, dataset_rid: str, response: Optional[requests.Response] = None):

--- a/src/foundry_dev_tools/foundry_api_client.py
+++ b/src/foundry_dev_tools/foundry_api_client.py
@@ -915,7 +915,7 @@ class FoundryRestClient:
             dataset_path_or_rid (str): Path to dataset (e.g. /Global/...)
                 or rid of dataset (e.g. ri.foundry.main.dataset...)
             branch (str): branch of the dataset
-            check_read_access (bool): default is True, checks if the user has read access ('compass:view')
+            check_read_access (bool): default is True, checks if the user has read access ('compass:read-resource')
                 to the dataset otherwise exception is thrown
 
         Returns:
@@ -930,7 +930,7 @@ class FoundryRestClient:
         dataset_rid = dataset_details["rid"]
         dataset_path = dataset_details["path"]
         if check_read_access:
-            if "compass:view" not in dataset_details["operations"]:
+            if "compass:read-resource" not in dataset_details["operations"]:
                 raise DatasetNoReadAccessError(dataset_rid)
         return {
             "dataset_path": dataset_path,

--- a/src/foundry_dev_tools/foundry_api_client.py
+++ b/src/foundry_dev_tools/foundry_api_client.py
@@ -2318,7 +2318,8 @@ class DatasetHasNoTransactionsError(FoundryAPIError):
 
 
 class DatasetNoReadAccessError(FoundryAPIError):
-    """Exception is thrown when user is missing 'compass:view' on the dataset."""
+    """Exception is thrown when user is missing 'compass:read-resource' on the dataset,
+    which normally comes with the Viewer role."""
 
     def __init__(self, dataset_rid: str, response: Optional[requests.Response] = None):
         """Pass parameters to constructor for later use and uniform error messages.


### PR DESCRIPTION
# Summary

[check_read_access](https://github.com/emdgroup/foundry-dev-tools/blob/10b7e748c9ab1e4230fdd290cedc67bcd5737843/src/foundry_dev_tools/foundry_api_client.py#L932) currently uses `compass:view` to check if the user has read access to the dataset. `compass:view` is not treated as a single operation but the Viewer Role, which translates to many operations. Unfortunately, in some cases the Viewer Role will not map to `compass:view` but something else. Therefore it's possible to have the Viewer role on a dataset but not `compass:view`.

Instead `compass:read-resource` is a better operation to be checked. Worth noting that because of markings / custom Roles it can still be possible that someone with `compass:read-resource` doesn't have access to the data. There isn't any single operation you can check to guarantee data access.

# Checklist

- [X] You agree with our [CLA](https://gist.githubusercontent.com/emdgroup-admin/16cc45ea4315c2ef29eb9d9afc36fcf5/raw/abb9c91f15278a62b9ac3e66144bcd27fa9485c2/CLA.md)
- [X] Included tests (or is not applicable).
- [X] Updated [documentation](https://emdgroup.github.io/foundry-dev-tools/) (or is not applicable).
- [X] Used [pre-commit hooks](https://emdgroup.github.io/foundry-dev-tools/develop.html#pre-commit-hooks-formatting) to format and lint the code.
