### PR TITLE
Include dataset_rid in DatasetAlreadyExistsError to make it easier to consume.

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog],
 and this project adheres to [Semantic Versioning].
 
+## [1.0.6] - 2023-03-31
+
+### Changed
+
+- Include dataset_rid in DatasetAlreadyExistsError to make it easier to consume. (#10)
+
 ## [1.0.5] - 2023-03-24
 
 ### Fixed

--- a/src/foundry_dev_tools/foundry_api_client.py
+++ b/src/foundry_dev_tools/foundry_api_client.py
@@ -2221,7 +2221,7 @@ class BranchNotFoundError(FoundryAPIError):
                 if transaction_rid is not None
                 else ""
             )
-            + " has no branch {branch}.\n"
+            + f"has no branch {branch}.\n"
             + (response.text if response is not None else "")
         )
         self.dataset_rid = dataset_rid

--- a/src/foundry_dev_tools/foundry_api_client.py
+++ b/src/foundry_dev_tools/foundry_api_client.py
@@ -120,7 +120,8 @@ class FoundryRestClient:
             json={"path": dataset_path},
         )
         if response.status_code == 400 and "DuplicateDatasetName" in response.text:
-            raise DatasetAlreadyExistsError(dataset_path)
+            rid = self.get_dataset_rid(dataset_path=dataset_path)
+            raise DatasetAlreadyExistsError(dataset_path=dataset_path, dataset_rid=rid)
         _raise_for_status_verbose(response)
         return response.json()
 
@@ -2275,8 +2276,10 @@ class DatasetNotFoundError(FoundryAPIError):
 class DatasetAlreadyExistsError(FoundryAPIError):
     """Exception is thrown when dataset already exists."""
 
-    def __init__(self, dataset_rid: str):
-        super().__init__(f"Dataset {dataset_rid} already exists.")
+    def __init__(self, dataset_path: str, dataset_rid: str):
+        super().__init__(f"Dataset {dataset_path=} {dataset_rid=} already exists.")
+        self.dataset_rid = dataset_rid
+        self.dataset_path = dataset_path
 
 
 class FolderNotFoundError(FoundryAPIError):

--- a/tests/test_foundry_api.py
+++ b/tests/test_foundry_api.py
@@ -75,8 +75,10 @@ def test_monster_integration_test(client):
     ds = client.create_dataset(dataset_path)
     assert "rid" in ds
     assert "fileSystemId" in ds
-    with pytest.raises(DatasetAlreadyExistsError):
+    with pytest.raises(DatasetAlreadyExistsError) as excinfo:
         client.create_dataset(dataset_path)
+    assert excinfo.value.dataset_rid == ds["rid"]
+    assert excinfo.value.dataset_path == dataset_path
 
     ds_returned = client.get_dataset(ds["rid"])
     assert "rid" in ds_returned


### PR DESCRIPTION
… consume.

# Summary

Enables this pattern in an application that uses the fsspec implementation and has one backing dataset per user:

```
from foundry_dev_tools import FoundryRestClient
from foundry_dev_tools.foundry_api_client import DatasetAlreadyExistsError
import fsspec

client = FoundryRestClient()

try:
    dataset = client.create_dataset("/path/user1")
    dataset_rid = dataset['rid']
    _ = client.create_branch(dataset_rid, 'master')
except DatasetAlreadyExistsError as exc:
    dataset_rid = exc.dataset_rid

fs = fsspec.filesystem("foundry", dataset=dataset_rid)

```

# Checklist

- [X] You agree with our [CLA](https://gist.githubusercontent.com/emdgroup-admin/16cc45ea4315c2ef29eb9d9afc36fcf5/raw/abb9c91f15278a62b9ac3e66144bcd27fa9485c2/CLA.md)
- [X] Included tests (or is not applicable).
- [-] Updated [documentation](https://emdgroup.github.io/foundry-dev-tools/) (or is not applicable).
- [X] Used [pre-commit hooks](https://emdgroup.github.io/foundry-dev-tools/develop.html#pre-commit-hooks-formatting) to format and lint the code.
