### PR TITLE
release v1.0.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,14 @@
 
   <a href="https://github.com/emdgroup/foundry-dev-tools/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/emdgroup/foundry-dev-tools/ci.yml?style=flat-square"/></img>
   <a href="https://github.com/emdgroup/foundry-dev-tools/actions/workflows/docs.yml"><img src="https://img.shields.io/github/actions/workflow/status/emdgroup/foundry-dev-tools/docs.yml?style=flat-square"/></img>
-  <a href="https://pypi.org/project/foundry-dev-tools/"><img src="https://img.shields.io/pypi/v/foundry-dev-tools.svg?style=flat-square"/></a>
-  <a href="https://pypi.org/project/foundry-dev-tools/"><img src="https://img.shields.io/pypi/pyversions/foundry-dev-tools?style=flat-square"/></a>
-  <a href="http://www.apache.org/licenses/LICENSE-2.0"><img src="https://shields.io/badge/License-Apache%202.0-green.svg?style=flat-square"/></a>
-  <a href="https://github.com/emdgroup/foundry-dev-tools/issues"><img src="https://img.shields.io/github/issues/emdgroup/foundry-dev-tools?color=important&style=flat-square"/></a>
-  <a href="https://github.com/emdgroup/foundry-dev-tools/pulls"><img src="https://img.shields.io/github/issues-pr/emdgroup/foundry-dev-tools?color=blueviolet&style=flat-square"/></a>
-
+  <a href="https://pypi.org/project/foundry-dev-tools/"><img src="https://img.shields.io/pypi/pyversions/foundry-dev-tools?style=flat-square&label=Supported%20Python%20versions&color=%23ffb86c"/></a>
+  <a href="https://pypi.org/project/foundry-dev-tools/"><img src="https://img.shields.io/pypi/v/foundry-dev-tools.svg?style=flat-square&label=PyPI%20version&color=%23bd93f9"/></a>
+  <a href="https://anaconda.org/conda-forge/foundry-dev-tools"><img src="https://img.shields.io/conda/vn/conda-forge/foundry-dev-tools.svg?style=flat-square&label=Conda%20Forge%20Version&color=%23bd93f9" alt="Conda Version"/></a>
+  <a href="https://pypi.org/project/foundry-dev-tools/"><img src="https://img.shields.io/pypi/dm/foundry-dev-tools?label=PyPI%20Downloads&style=flat-square&color=%236272a4"/></a>
+  <a href="https://anaconda.org/conda-forge/foundry-dev-tools"><img src="https://img.shields.io/conda/dn/conda-forge/foundry-dev-tools.svg?style=flat-square&label=Conda%20Forge%20Downloads&color=%236272a4" alt="Conda Downloads"/></a>
+  <a href="https://github.com/emdgroup/foundry-dev-tools/issues"><img src="https://img.shields.io/github/issues/emdgroup/foundry-dev-tools?style=flat-square&color=%23ff79c6"/></a>
+  <a href="https://github.com/emdgroup/foundry-dev-tools/pulls"><img src="https://img.shields.io/github/issues-pr/emdgroup/foundry-dev-tools?style=flat-square&color=%23ff79c6"/></a>
+  <a href="http://www.apache.org/licenses/LICENSE-2.0"><img src="https://shields.io/badge/License-Apache%202.0-green.svg?style=flat-square&color=%234c1"/></a>
   <p><a href="https://emdgroup.github.io/foundry-dev-tools">Documentation</a></p>
 
   <a href="https://emdgroup.github.io/foundry-dev-tools/installation.html">Installation<a/>
@@ -65,8 +67,14 @@ high level entrypoints to Foundry DevTools:
 
 ## Quickstart
 
+With pip:
 ```shell
 pip install foundry-dev-tools
+```
+
+With conda or mamba on the conda-forge channel:
+```shell
+conda install -c conda-forge foundry-dev-tools
 ```
 
 [Further instructions](https://emdgroup.github.io/foundry-dev-tools/installation.html) can be found in our documentation.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog],
 and this project adheres to [Semantic Versioning].
 
+## [1.0.8] - 2023-04-17
+
+### Added
+
+- python 3.11 support, as pyspark 3.4 gained support for it (#13)
+- conda-forge badges to the README (#13)
+
+### Fixed
+
+- typo in docs (#12)
+
+### Removed
+
+- pandas<2 restriction, as pyspark 3.4 supports it (#13)
+
+
 ## [1.0.7] - 2023-04-05
 
 ### Added

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -33,8 +33,14 @@ jwt=<paste your foundry token here>
 We recommend using a new [conda environment] or [python environment],
 after you activated it, just run:
 
-```bash
+With pip:
+```shell
 pip install foundry-dev-tools
+```
+
+With conda or mamba on the conda-forge channel:
+```shell
+conda install -c conda-forge foundry-dev-tools
 ```
 
 or, if you have the repository locally available and want to tinker with the source code

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,6 +25,7 @@ classifiers =
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     Intended Audience :: Developers
     Operating System :: POSIX :: Linux
     Operating System :: MacOS
@@ -39,7 +40,7 @@ package_dir =
     =src
 install_requires =
     pyarrow
-    pandas < 2 # until pyspark supports v2 or also sets this limitation
+    pandas
     requests
     fs
     backoff


### PR DESCRIPTION
# Summary

- support pandas >=2 again as pyspark supports it now, this also enables python 3.11 support
- add conda-forge badges to README
- prepare release v1.0.8
  - add changelog entries

# Checklist

- [x] You agree with our [CLA](https://gist.githubusercontent.com/emdgroup-admin/16cc45ea4315c2ef29eb9d9afc36fcf5/raw/abb9c91f15278a62b9ac3e66144bcd27fa9485c2/CLA.md)
- [x] Included tests (or is not applicable).
- [x] Updated [documentation](https://emdgroup.github.io/foundry-dev-tools/) (or is not applicable).
- [x] Used [pre-commit hooks](https://emdgroup.github.io/foundry-dev-tools/develop.html#pre-commit-hooks-formatting) to format and lint the code.
