### PR TITLE
change useragent from Foundry DevTools to foundry-dev-tools

### DIFF
--- a/src/foundry_dev_tools/foundry_api_client.py
+++ b/src/foundry_dev_tools/foundry_api_client.py
@@ -90,7 +90,7 @@ class FoundryRestClient:
     def _headers(self):
         return {
             "User-Agent": requests.utils.default_user_agent(
-                f"Foundry DevTools/{fdt_version}/python-requests"
+                f"foundry-dev-tools/{fdt_version}/python-requests"
             ),
             "Content-Type": "application/json",
             "Authorization": f"Bearer {_get_auth_token(self._config)}",
@@ -1711,7 +1711,7 @@ class FoundrySqlClient:
     def _get_initial_headers(self, session_authorization=None):
         return {
             "User-Agent": requests.utils.default_user_agent(
-                f"Foundry DevTools/{fdt_version}/python-requests"
+                f"foundry-dev-tools/{fdt_version}/python-requests"
             ),
             "Accept": "application/json",
             "Accept-Encoding": "gzip, deflate, br",
@@ -2048,7 +2048,7 @@ def _get_oauth2_client_credentials_token(
     """
     headers = {
         "User-Agent": requests.utils.default_user_agent(
-            f"Foundry DevTools/{fdt_version}/python-requests"
+            f"foundry-dev-tools/{fdt_version}/python-requests"
         ),
         "Authorization": "Basic "
         + base64.b64encode(bytes(client_id + ":" + client_secret, "ISO-8859-1")).decode(

--- a/tests/test_foundry_api.py
+++ b/tests/test_foundry_api.py
@@ -63,7 +63,7 @@ def test_sso_config(mocker, tmpdir):
         mock_get_user_credentials.return_value.token = "access-token"
 
         assert client._headers()["Authorization"] == "Bearer access-token"
-        assert "Foundry DevTools" in client._headers()["User-Agent"]
+        assert client._headers()["User-Agent"].startswith("foundry-dev-tools")
 
 
 @pytest.mark.integration


### PR DESCRIPTION
# Summary

Changed user-agent of the FoundryRestClient from "Foundry DevTools/x.y.z/python-requests/x.y.z" to "foundry-dev-tools/x.y.z/python-requests/x.y.z"

# Checklist

- [x] You agree with our [CLA](https://gist.githubusercontent.com/emdgroup-admin/16cc45ea4315c2ef29eb9d9afc36fcf5/raw/abb9c91f15278a62b9ac3e66144bcd27fa9485c2/CLA.md)
- [x] Included tests (or is not applicable).
- [x] Updated [documentation](https://emdgroup.github.io/foundry-dev-tools/) (or is not applicable).
- [x] Used [pre-commit hooks](https://emdgroup.github.io/foundry-dev-tools/develop.html#pre-commit-hooks-formatting) to format and lint the code.
