### PR TITLE
fix file >2GB upload

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog],
 and this project adheres to [Semantic Versioning].
 
+## [1.0.9] - 2023-04-27
+
+### Fixed
+
+- file upload for files greater than 2GB (#16)
+
 ## [1.0.8] - 2023-04-17
 
 ### Added
@@ -96,6 +102,7 @@ and this project adheres to [Semantic Versioning].
 
 [Keep a Changelog]: https://keepachangelog.com/en/1.0.0/
 [Semantic Versioning]: https://semver.org/spec/v2.0.0.html
+[1.0.9]: https://github.com/emdgroup/foundry-dev-tools/compare/v1.0.8...v1.0.9
 [1.0.8]: https://github.com/emdgroup/foundry-dev-tools/compare/v1.0.7...v1.0.8
 [1.0.7]: https://github.com/emdgroup/foundry-dev-tools/compare/v1.0.6...v1.0.7
 [1.0.6]: https://github.com/emdgroup/foundry-dev-tools/compare/v1.0.5...v1.0.6

--- a/src/foundry_dev_tools/foundry_api_client.py
+++ b/src/foundry_dev_tools/foundry_api_client.py
@@ -550,7 +550,7 @@ class FoundryRestClient:
                 f"{self.data_proxy}/dataproxy/datasets/{dataset_rid}/"
                 f"transactions/{transaction_rid}/putFile",
                 params={"logicalPath": path_in_foundry_dataset},
-                data=file.read(),
+                data=file,
                 headers={
                     "Content-Type": "application/octet-stream",
                     "Authorization": self._headers()["Authorization"],
@@ -2073,7 +2073,6 @@ def _get_palantir_oauth_token(
     foundry_url: str, client_id: str, client_secret: str = None
 ) -> str:
     if oauth_provider := _is_palantir_oauth_client_installed():
-
         credentials = oauth_provider.get_user_credentials(
             scopes=[
                 "offline_access",


### PR DESCRIPTION
# Summary

<!-- summary of your changes -->
if the file to upload was greater than 2GB an ssl error occured.
This can be mitigated by passing the file object to requests instead of the bytes.

# Checklist

- [x] You agree with our [CLA](https://gist.githubusercontent.com/emdgroup-admin/16cc45ea4315c2ef29eb9d9afc36fcf5/raw/abb9c91f15278a62b9ac3e66144bcd27fa9485c2/CLA.md)
- [x] Included tests (or is not applicable).
- [x] Updated [documentation](https://emdgroup.github.io/foundry-dev-tools/) (or is not applicable).
- [x] Used [pre-commit hooks](https://emdgroup.github.io/foundry-dev-tools/develop.html#pre-commit-hooks-formatting) to format and lint the code.
