### PR TITLE
Feat/better sql exceptions

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,14 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog],
 and this project adheres to [Semantic Versioning].
 
+## [1.0.11] - 2023-05-16
+
+### Changed
+- better SQL exceptions (#20)
+
+### Fixed
+- pip installation documentation for zsh users (#19)
+
 ## [1.0.10] - 2023-05-16
 
-## Changed
+### Changed
 
 - use ruff and black instead of pylint and ufmt (#15)
 - converted the subprocess calls with git to python only imitations (#15)
 
-## Fixed
+### Fixed
 
 - environment variables didn't take precedence (#15)
 
@@ -112,6 +120,7 @@ and this project adheres to [Semantic Versioning].
 
 [Keep a Changelog]: https://keepachangelog.com/en/1.0.0/
 [Semantic Versioning]: https://semver.org/spec/v2.0.0.html
+[1.0.10]: https://github.com/emdgroup/foundry-dev-tools/compare/v1.0.10...v1.0.11
 [1.0.10]: https://github.com/emdgroup/foundry-dev-tools/compare/v1.0.9...v1.0.10
 [1.0.9]: https://github.com/emdgroup/foundry-dev-tools/compare/v1.0.8...v1.0.9
 [1.0.8]: https://github.com/emdgroup/foundry-dev-tools/compare/v1.0.7...v1.0.8

--- a/src/foundry_dev_tools/foundry_api_client.py
+++ b/src/foundry_dev_tools/foundry_api_client.py
@@ -1935,7 +1935,7 @@ def _extract_branch_from_sql_error(response):
             .replace("]", "")
         )
     except Exception as e:
-        print(e)
+        print(e, file=sys.stderr)
         return None
 
 

--- a/src/foundry_dev_tools/foundry_api_client.py
+++ b/src/foundry_dev_tools/foundry_api_client.py
@@ -1915,13 +1915,28 @@ def _transform_bad_request_response_to_exception(response):
         and response.json()["errorName"]
         == "FoundrySqlServer:InvalidDatasetCannotAccess"
     ):
-        raise BranchNotFoundError("SQL", "SQL")
+        raise BranchNotFoundError(
+            response.json()["parameters"]["datasetRid"],
+            _extract_branch_from_sql_error(response),
+        )
     if (
         response.status_code == requests.codes.bad
         and response.json()["errorName"]
         == "FoundrySqlServer:InvalidDatasetPathNotFound"
     ):
-        raise DatasetNotFoundError("SQL")
+        raise DatasetNotFoundError(response.json()["parameters"]["path"])
+
+
+def _extract_branch_from_sql_error(response):
+    try:
+        return (
+            response.json()["parameters"]["userFriendlyMessage"]
+            .split("[")[1]
+            .replace("]", "")
+        )
+    except Exception as e:
+        print(e)
+        return None
 
 
 def _raise_for_status_verbose(response: requests.Response):

--- a/tests/test_foundry_sql_client.py
+++ b/tests/test_foundry_sql_client.py
@@ -176,6 +176,18 @@ def test_legacy_fallback(mocker, iris_dataset, client):
     assert iris.shape == (100, 5)
     spy.assert_called()
 
+    spy.reset_mock()
+    import sys
+
+    pyarrow = sys.modules["pyarrow"]
+    sys.modules["pyarrow"] = None
+
+    iris = client.query_foundry_sql(f"SELECT * FROM `{iris_dataset[1]}`")
+    assert iris.shape == (150, 5)
+    spy.assert_called()
+
+    sys.modules["pyarrow"] = pyarrow
+
 
 @pytest.mark.integration()
 def test_exceptions(iris_dataset, iris_no_schema_dataset):

--- a/tests/test_foundry_sql_client.py
+++ b/tests/test_foundry_sql_client.py
@@ -180,15 +180,28 @@ def test_legacy_fallback(mocker, iris_dataset, client):
 @pytest.mark.integration()
 def test_exceptions(iris_dataset, iris_no_schema_dataset):
     sql_client1 = FoundrySqlClient(branch="doesNotExist")
-    with pytest.raises(BranchNotFoundError):
+    with pytest.raises(BranchNotFoundError) as exc:
         sql_client1.query(f"SELECT * FROM `{iris_dataset[1]}` LIMIT 100")
+    assert exc.value.dataset_rid == iris_dataset[0]
+    assert exc.value.branch == "doesNotExist"
 
     client = FoundrySqlClient()
     with pytest.raises(DatasetHasNoSchemaError):
         client.query(f"SELECT * FROM `{iris_no_schema_dataset[1]}` LIMIT 100")
 
-    with pytest.raises(DatasetNotFoundError):
+    with pytest.raises(DatasetNotFoundError) as exc:
         client.query("SELECT * FROM `/namespace1/does-not_exists/` LIMIT 100")
+    assert exc.value.dataset_rid == "/namespace1/does-not_exists/"
+
+    with pytest.raises(BranchNotFoundError) as exc:
+        client.query(
+            "SELECT * FROM `ri.foundry.main.dataset.1337fb9d-1234-43c7-b83f-768f2b843b94` LIMIT 100"
+        )
+    assert (
+        exc.value.dataset_rid
+        == "ri.foundry.main.dataset.1337fb9d-1234-43c7-b83f-768f2b843b94"
+    )
+    assert exc.value.branch == "master"
 
     with pytest.raises(FoundrySqlQueryFailedError):
         client.query(f"SELECT foo, bar, FROM `{iris_dataset[1]}` LIMIT 100")


### PR DESCRIPTION
# Summary

* Got tired of the "SQL" in error messages from the SQL Server. Extract as much as possible from the error messages.
* fallback to legacy endpoint of pyarrow dependency not available (this will help us in WASM).

# Checklist

- [X] You agree with our [CLA](https://gist.githubusercontent.com/emdgroup-admin/16cc45ea4315c2ef29eb9d9afc36fcf5/raw/abb9c91f15278a62b9ac3e66144bcd27fa9485c2/CLA.md)
- [X] Included tests (or is not applicable).
- [x] Updated [documentation](https://emdgroup.github.io/foundry-dev-tools/) (or is not applicable).
- [X] Used [pre-commit hooks](https://emdgroup.github.io/foundry-dev-tools/develop.html#pre-commit-hooks-formatting) to format and lint the code.
