### PR TITLE
Move to ARROW_V1 which consistently returns arrow format in SQL 

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog],
 and this project adheres to [Semantic Versioning].
 
+## [1.0.12] - 2023-06-01
+
+### Added
+- SQLReturnType enum (#21)
+
+### Changed
+- move to arrow_v1 for sql queries (#21)
+
+### Removed
+- FoundrySQLClient (#21)
+
 ## [1.0.11] - 2023-05-23
 
 ### Changed
@@ -120,7 +131,8 @@ and this project adheres to [Semantic Versioning].
 
 [Keep a Changelog]: https://keepachangelog.com/en/1.0.0/
 [Semantic Versioning]: https://semver.org/spec/v2.0.0.html
-[1.0.10]: https://github.com/emdgroup/foundry-dev-tools/compare/v1.0.10...v1.0.11
+[1.0.12]: https://github.com/emdgroup/foundry-dev-tools/compare/v1.0.11...v1.0.12
+[1.0.11]: https://github.com/emdgroup/foundry-dev-tools/compare/v1.0.10...v1.0.11
 [1.0.10]: https://github.com/emdgroup/foundry-dev-tools/compare/v1.0.9...v1.0.10
 [1.0.9]: https://github.com/emdgroup/foundry-dev-tools/compare/v1.0.8...v1.0.9
 [1.0.8]: https://github.com/emdgroup/foundry-dev-tools/compare/v1.0.7...v1.0.8

--- a/src/foundry_dev_tools/foundry_api_client.py
+++ b/src/foundry_dev_tools/foundry_api_client.py
@@ -19,7 +19,7 @@ import tempfile
 import time
 import warnings
 from contextlib import contextmanager
-from enum import Enum, EnumType
+from enum import Enum, EnumMeta
 from importlib.metadata import PackageNotFoundError, version
 from itertools import repeat
 from pathlib import Path
@@ -68,7 +68,7 @@ def _poolcontext(*args, **kwargs):
     pool.terminate()
 
 
-class EnumContainsMeta(EnumType):
+class EnumContainsMeta(EnumMeta):
     """Metaclass for the SQLReturnType.
 
     It implements a proper __contains__ like 3.12 does.
@@ -77,7 +77,7 @@ class EnumContainsMeta(EnumType):
     def __contains__(cls, value):
         """Backported a __contains__ from 3.12."""
         if sys.version_info >= (3, 12):
-            return Enum.__contains__(cls, value)
+            return EnumMeta.__contains__(cls, value)
         if isinstance(value, cls) and value._name_ in cls._member_map_:
             return True
         return value in cls._value2member_map_

--- a/src/foundry_dev_tools/foundry_api_client.py
+++ b/src/foundry_dev_tools/foundry_api_client.py
@@ -9,7 +9,6 @@ import base64
 import builtins
 import functools
 import io
-import json
 import logging
 import multiprocessing
 import os
@@ -23,13 +22,15 @@ from contextlib import contextmanager
 from importlib.metadata import PackageNotFoundError, version
 from itertools import repeat
 from pathlib import Path
-from typing import IO, TYPE_CHECKING, AnyStr
+from typing import IO, TYPE_CHECKING, AnyStr, List
 from urllib.parse import quote, quote_plus
 
 import palantir_oauth_client
 import requests
 
 import foundry_dev_tools.config
+
+DEFAULT_REQUESTS_CONNECT_TIMEOUT = 10
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -97,7 +98,9 @@ class FoundryRestClient:
         self.data_proxy = f"{api_base}/foundry-data-proxy/api"
         self.schema_inference = f"{api_base}/foundry-schema-inference/api"
         self.multipass = f"{api_base}/multipass/api"
-        self._api_base = api_base
+        self.foundry_sql_server_api = (
+            f"{self._config['foundry_url']}/foundry-sql-server/api"
+        )
         self._requests_verify_value = _determine_requests_verify_value(self._config)
 
     def _headers(self):
@@ -1250,8 +1253,12 @@ class FoundryRestClient:
         return response
 
     def query_foundry_sql_legacy(
-        self, query: str, branch: str = "master"
-    ) -> "tuple[dict, list]":
+        self,
+        query: str,
+        branch: str = "master",
+        return_type="raw",
+        timeout: int = 600,
+    ) -> "tuple[dict, List[List]] | pd.core.frame.DataFrame | pyspark.sql.DataFrame | pa.Table":
         """Queries the dataproxy query API with spark SQL.
 
         Example:
@@ -1261,6 +1268,10 @@ class FoundryRestClient:
         Args:
             query (str): the sql query
             branch (str): the branch of the dataset / query
+            return_type (str, tuple[dict, List[List]] |  pandas | arrow | spark): Whether to return
+                :external+pandas:py:class:`pandas.DataFrame`, :external+pyarrow:py:class:`pyarrow.Table` or
+                :external+spark:py:class:`~pyspark.sql.DataFrame` or a Tuple of (foundry_schema, data)
+            timeout (int): the query timeout, default value is 600 seconds
 
         Returns:
             Tuple (dict, list):
@@ -1278,6 +1289,10 @@ class FoundryRestClient:
             DatasetHasNoSchemaError: if dataset has no schema
             BranchNotFoundError: if branch was not found
         """
+        if return_type not in {"raw", "pandas", "arrow", "spark"}:
+            raise AssertionError(
+                f"return_type ({return_type}) should be one of raw, pandas, arrow or spark"
+            )
         response = _request(
             "POST",
             f"{self.data_proxy}/dataproxy/queryWithFallbacks",
@@ -1285,6 +1300,7 @@ class FoundryRestClient:
             verify=self._verify(),
             params={"fallbackBranchIds": [branch]},
             json={"query": query},
+            read_timeout=timeout,
         )
 
         if (
@@ -1308,24 +1324,66 @@ class FoundryRestClient:
 
         _raise_for_status_verbose(response)
         response_json = response.json()
-        return response_json["foundrySchema"], response_json["rows"]
+        if return_type == "raw":
+            return response_json["foundrySchema"], response_json["rows"]
+        if return_type == "pandas" or return_type == "arrow":
+            import pandas as pd
+
+            pdf = pd.DataFrame(
+                data=response_json["rows"],
+                columns=[
+                    e["name"] for e in response_json["foundrySchema"]["fieldSchemaList"]
+                ],
+            )
+            if return_type == "pandas":
+                return pdf
+            if return_type == "arrow":
+                import pyarrow as pa
+
+                return pa.Table.from_pandas(pdf)
+            return None
+        if return_type == "spark":
+            from foundry_dev_tools.utils.converter.foundry_spark import (
+                foundry_schema_to_spark_schema,
+                foundry_sql_data_to_spark_dataframe,
+            )
+
+            return foundry_sql_data_to_spark_dataframe(
+                data=response_json["rows"],
+                spark_schema=foundry_schema_to_spark_schema(
+                    response_json["foundrySchema"]
+                ),
+            )
+        return None
 
     def query_foundry_sql(
-        self, query, branch="master", return_type="pandas"
+        self,
+        query,
+        branch="master",
+        return_type="pandas",
+        timeout: int = 600,
     ) -> "pd.core.frame.DataFrame | pa.Table | pyspark.sql.DataFrame":
         """Queries the Foundry SQL server with spark SQL dialect.
 
         Uses Arrow IPC to communicate with the Foundry SQL Server Endpoint.
 
+        Falls back to query_foundry_sql_legacy in case pyarrow is not installed or the query does not return
+        Arrow Format.
+
         Example:
-            client.query_foundry_sql("SELECT * FROM `/Global/Foundry Operations/Foundry Support/iris`")
+            df1 = client.query_foundry_sql("SELECT * FROM `/Global/Foundry Operations/Foundry Support/iris`")
+
+            query = ("SELECT col1 FROM `{start_transaction_rid}:{end_transaction_rid}@{branch}`.`{dataset_path_or_rid}`"
+                  "WHERE filterColumns = 'value1' LIMIT 1")
+            df2 = client.query_foundry_sql(query)
 
         Args:
-            query (str): the sql query
-            branch (str): the branch of the dataset / query
+            query (str): The SQL Query in Foundry Spark Dialect (use backticks instead of quotes)
+            branch (str): The branch of the dataset / query
             return_type (str, pandas | arrow | spark): Whether to return
                 :external+pandas:py:class:`pandas.DataFrame`, :external+pyarrow:py:class:`pyarrow.Table` or
                 :external+spark:py:class:`~pyspark.sql.DataFrame`
+            timeout (int): Query Timeout, default value is 600 seconds
 
         Returns:
             :external+pandas:py:class:`~pandas.DataFrame` | :external+pyarrow:py:class:`~pyarrow.Table` | :external+spark:py:class:`~pyspark.sql.DataFrame`:
@@ -1340,33 +1398,16 @@ class FoundryRestClient:
             raise AssertionError(
                 f"return_type ({return_type}) should be one of pandas, arrow or spark"
             )
-        foundry_sql_client = FoundrySqlClient(config=self._config, branch=branch)
         try:
-            return foundry_sql_client.query(query=query, return_type=return_type)
+            return self._query_fsql(query=query, branch=branch, return_type=return_type)
         except (FoundrySqlSerializationFormatNotImplementedError, ImportError) as exc:
             if return_type == "arrow":
                 raise ValueError(
                     "Only direct read eligible queries can be returned as arrow Table. "
                     "Consider using setting return_type to 'pandas'."
                 ) from exc
-            foundry_schema, data = self.query_foundry_sql_legacy(query, branch)
-
-            if return_type == "pandas":
-                import pandas as pd
-
-                return pd.DataFrame(
-                    data=data,
-                    columns=[e["name"] for e in foundry_schema["fieldSchemaList"]],
-                )
-
-            from foundry_dev_tools.utils.converter.foundry_spark import (
-                foundry_schema_to_spark_schema,
-                foundry_sql_data_to_spark_dataframe,
-            )
-
-            return foundry_sql_data_to_spark_dataframe(
-                data=data,
-                spark_schema=foundry_schema_to_spark_schema(foundry_schema),
+            return self.query_foundry_sql_legacy(
+                query=query, branch=branch, return_type=return_type, timeout=timeout
             )
 
     def get_user_info(self) -> dict:
@@ -1708,94 +1749,37 @@ class FoundryRestClient:
         _raise_for_status_verbose(response)
         return response.json()
 
-
-class FoundrySqlClient:
-    """Class to interact with Foundry's SQL Server using ARROW IPC Protocol."""
-
-    def __init__(self, config: "dict | None" = None, branch="master"):
-        """Construct an instance of FoundrySqlClient.
-
-        Args:
-            config (dict): configuration dictionary, equivalent to FoundryRestClient
-            branch (str):  default = master, all queries will be executed against this default branch
-
-        """
-        self._config = foundry_dev_tools.config.Configuration.get_config(config)
-        self._requests_verify_value = _determine_requests_verify_value(self._config)
-        self.foundry_sql_server_api = (
-            f"{self._config['foundry_url']}/foundry-sql-server/api"
-        )
-        self._headers = self._get_initial_headers(session_authorization=None)
-        self.branch = branch
-        self.session_id, self.session_auth_token = self._establish_session(
-            branch=branch
-        )
-        self._headers = self._get_initial_headers(
-            session_authorization=self.session_auth_token
-        )
-
-    def _get_initial_headers(self, session_authorization=None):
-        return {
-            "User-Agent": requests.utils.default_user_agent(
-                f"foundry-dev-tools/{FDT_VERSION}/python-requests"
-            ),
-            "Accept": "application/json",
-            "Accept-Encoding": "gzip, deflate, br",
-            "Content-Type": "application/json",
-            "Session-Authorization": session_authorization,
-            "Authorization": f"Bearer {_get_auth_token(self._config)}",
-        }
-
-    def _establish_session(self, branch="master") -> "tuple[str, str]":
+    def _execute_fsql_query(self, query: str, branch="master", timeout=600) -> dict:
         response = _request(
             "POST",
-            f"{self.foundry_sql_server_api}/sessions",
-            headers=self._headers,
-            verify=self._requests_verify_value,
-            json={
-                "configuration": {
-                    "fallbackBranchIds": [branch],
-                    "queryTimeoutMillis": None,
-                },
-                "protocolVersion": None,
-            },
-        )
-        _raise_for_status_verbose(response)
-        response_json = response.json()
-        session_id = response_json["sessionId"]
-        session_auth_token = response_json["sessionAuthToken"]
-        return session_id, session_auth_token
-
-    def _prepare_and_execute(self, query: str) -> dict:
-        response = _request(
-            "POST",
-            f"{self.foundry_sql_server_api}/sessions/"
-            f"{self.session_id}/prepare-and-execute-statement",
-            headers=self._headers,
+            f"{self.foundry_sql_server_api}/queries/execute",
+            headers=self._headers(),
             verify=self._requests_verify_value,
             json={
                 "dialect": "SPARK",
+                "fallbackBranchIds": [branch],
                 "parameters": {
                     "type": "unnamedParameterValues",
                     "unnamedParameterValues": [],
                 },
                 "query": query,
-                "serializationProtocol": "ARROW",
+                "serializationProtocol": "ARROW_V1",
+                "timeout": timeout,
             },
         )
         _transform_bad_request_response_to_exception(response)
         _raise_for_status_verbose(response)
         return response.json()
 
-    def _poll_for_query_completion(self, initial_response_json: dict, timeout=600):
+    def _poll_fsql_query_status(self, initial_response_json: dict, timeout=600):
         start_time = time.time()
-        statement_id = initial_response_json["statementId"]
+        query_id = initial_response_json["queryId"]
         response_json = initial_response_json
         while response_json["status"]["type"] == "running":
             response = _request(
-                "POST",
-                f"{self.foundry_sql_server_api}/" f"statements/{statement_id}/status",
-                headers=self._headers,
+                "GET",
+                f"{self.foundry_sql_server_api}/queries/{query_id}/status",
+                headers=self._headers(),
                 verify=self._requests_verify_value,
                 json={},
             )
@@ -1807,12 +1791,12 @@ class FoundrySqlClient:
                 raise FoundrySqlQueryClientTimedOutError(timeout)
             time.sleep(0.2)
 
-    def _read_results_arrow(
-        self, statement_id: str
+    def _read_fsql_query_results_arrow(
+        self, query_id: str
     ) -> "pa.ipc.RecordBatchStreamReader":
         import pyarrow as pa
 
-        headers = self._headers
+        headers = self._headers()
         headers["Accept"] = "application/octet-stream"
         headers["Content-Type"] = "application/json"
         # Couldn't get preload_content=False and gzip content-encoding to work together
@@ -1827,9 +1811,8 @@ class FoundrySqlClient:
         # and noticed that preloading content is significantly faster than stream=True
 
         response = _request(
-            "POST",
-            f"{self.foundry_sql_server_api}/" f"statements/{statement_id}/results",
-            data=json.dumps({}).encode("utf-8"),
+            "GET",
+            f"{self.foundry_sql_server_api}/queries/{query_id}/results",
             headers=headers,
         )
         bytes_io = io.BytesIO(response.content)
@@ -1845,54 +1828,34 @@ class FoundrySqlClient:
             # The query does not select from a column with a type that is ineligible for direct read.
             # Ineligible types are array, map, and struct.
 
+            # Mai 2023: ARROW_V1 seems to consistently return ARROW format and not fallback to JSON.
+
             raise FoundrySqlSerializationFormatNotImplementedError()
 
         return pa.ipc.RecordBatchStreamReader(bytes_io)
 
-    def query(
-        self, query: str, timeout=600, return_type="pandas"
+    def _query_fsql(
+        self,
+        query: str,
+        branch="master",
+        return_type: str = "pandas",
+        timeout: int = 600,
     ) -> "pd.core.frame.DataFrame | pa.Table | pyspark.sql.DataFrame":
-        """Queries the foundry sql endpoint. Current dialect is hard-coded to SPARK.
-
-        Example Queries:
-
-        .. code-block:: python
-
-         # direct read if dataset is backed by parquet files, no size limit
-         df1 = client.query(f'SELECT * FROM `{dataset_path}`')
-
-         query = ("SELECT col1 FROM `{start_transaction_rid}:{end_transaction_rid}@{branch}`.`{dataset_path_or_rid}`"
-                  "WHERE filterColumns = 'value1' LIMIT 1")
-         df2 = client.query(query)
-
-        Args:
-            query (str): Query
-            timeout (float): default value 600 seconds
-            return_type (str: pandas | arrow | spark): return type, one of pandas, arrow or spark.
-                Whether to return :external+pandas:py:class:`~pandas.DataFrame`,
-                :external+spark:py:class:`~pyspark.sql.DataFrame`
-                or :external+pyarrow:py:class:`~pyarrow.Table`
-
-        Returns:
-             :external+pandas:py:class:`~pandas.DataFrame` | :external+spark:py:class:`~pyspark.sql.DataFrame` |
-                :external+pyarrow:py:class:`~pyarrow.Table`:
-                A pandas dataframe, pyspark dataframe or pyarrow Table with the result
-
-
-
-        """
         if return_type not in {"pandas", "arrow", "spark"}:
             raise AssertionError(
                 f"return_type ({return_type}) should be one of pandas, arrow or spark"
             )
 
-        response_json = self._prepare_and_execute(query)
-        statement_id = response_json["statementId"]
+        response_json = self._execute_fsql_query(query, branch=branch, timeout=timeout)
+        query_id = response_json["queryId"]
+        status = response_json["status"]
 
-        self._poll_for_query_completion(
-            initial_response_json=response_json, timeout=timeout
-        )
-        arrow_stream_reader = self._read_results_arrow(statement_id)
+        if status != {"ready": {}, "type": "ready"}:
+            self._poll_fsql_query_status(
+                initial_response_json=response_json, timeout=timeout
+            )
+
+        arrow_stream_reader = self._read_fsql_query_results_arrow(query_id=query_id)
         if return_type == "pandas":
             return arrow_stream_reader.read_pandas()
         if return_type == "spark":
@@ -2112,7 +2075,15 @@ def _get_palantir_oauth_token(
 
 
 def _request(*args, **kwargs):
-    return requests.request(*args, **kwargs, timeout=60)
+    if "read_timeout" in kwargs:
+        read_timeout = kwargs["read_timeout"]
+        del kwargs["read_timeout"]
+        return requests.request(
+            *args,
+            **kwargs,
+            timeout=(DEFAULT_REQUESTS_CONNECT_TIMEOUT, read_timeout),
+        )
+    return requests.request(*args, **kwargs, timeout=DEFAULT_REQUESTS_CONNECT_TIMEOUT)
 
 
 class FoundryDevToolsError(Exception):

--- a/src/foundry_dev_tools/foundry_api_client.py
+++ b/src/foundry_dev_tools/foundry_api_client.py
@@ -1345,22 +1345,25 @@ class FoundryRestClient:
         response_json = response.json()
         if return_type == SQLReturnType.RAW:
             return response_json["foundrySchema"], response_json["rows"]
-        if return_type == SQLReturnType.PANDAS or return_type == SQLReturnType.ARROW:
+        if return_type == SQLReturnType.PANDAS:
             import pandas as pd
 
-            pdf = pd.DataFrame(
+            return pd.DataFrame(
                 data=response_json["rows"],
                 columns=[
                     e["name"] for e in response_json["foundrySchema"]["fieldSchemaList"]
                 ],
             )
-            if return_type == SQLReturnType.PANDAS:
-                return pdf
-            if return_type == SQLReturnType.ARROW:
-                import pyarrow as pa
+        if return_type == SQLReturnType.ARROW:
+            import pyarrow as pa
 
-                return pa.Table.from_pandas(pdf)
-        elif return_type == SQLReturnType.SPARK:
+            return pa.table(
+                data=response_json["rows"],
+                names=[
+                    e["name"] for e in response_json["foundrySchema"]["fieldSchemaList"]
+                ],
+            )
+        if return_type == SQLReturnType.SPARK:
             from foundry_dev_tools.utils.converter.foundry_spark import (
                 foundry_schema_to_spark_schema,
                 foundry_sql_data_to_spark_dataframe,

--- a/src/foundry_dev_tools/foundry_api_client.py
+++ b/src/foundry_dev_tools/foundry_api_client.py
@@ -1408,9 +1408,7 @@ class FoundryRestClient:
 
         Example:
             df1 = client.query_foundry_sql("SELECT * FROM `/Global/Foundry Operations/Foundry Support/iris`")
-
-            query = ("SELECT col1 FROM `{start_transaction_rid}:{end_transaction_rid}@{branch}`.`{dataset_path_or_rid}`"
-                  "WHERE filterColumns = 'value1' LIMIT 1")
+            query = ("SELECT col1 FROM `{start_transaction_rid}:{end_transaction_rid}@{branch}`.`{dataset_path_or_rid}` WHERE filterColumns = 'value1' LIMIT 1")
             df2 = client.query_foundry_sql(query)
 
         Args:

--- a/src/foundry_dev_tools/utils/converter/foundry_spark.py
+++ b/src/foundry_dev_tools/utils/converter/foundry_spark.py
@@ -210,7 +210,7 @@ def foundry_sql_data_to_spark_dataframe(
     """Converts the result of a foundry sql API query to a spark dataframe.
 
     Args:
-        data (list,list): list of list of data
+        data (List[List]): list of list of data
         spark_schema (:external+spark:py:class:`~pyspark.sql.types.StructType`): the spark schema to apply
 
     Returns:

--- a/src/foundry_dev_tools/utils/converter/foundry_spark.py
+++ b/src/foundry_dev_tools/utils/converter/foundry_spark.py
@@ -1,7 +1,7 @@
 """Helper function for conversion of data structures."""
 
 import tempfile
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, List
 
 from foundry_dev_tools.utils.importer import import_optional_dependency
 from foundry_dev_tools.utils.spark import get_spark_session
@@ -205,7 +205,7 @@ def _parse_complex_type(field) -> dict:
 
 
 def foundry_sql_data_to_spark_dataframe(
-    data: "tuple[list, list]", spark_schema: "pyspark.sql.types.StructType"
+    data: "List[List]", spark_schema: "pyspark.sql.types.StructType"
 ) -> "pyspark.sql.DataFrame":
     """Converts the result of a foundry sql API query to a spark dataframe.
 

--- a/tests/test_foundry_api.py
+++ b/tests/test_foundry_api.py
@@ -514,7 +514,6 @@ def test_query_sql(client, mocker, iris_dataset):
     spy = mocker.spy(FoundryRestClient, "query_foundry_sql_legacy")
 
     iris_pdf = client.query_foundry_sql(f"SELECT * FROM `{iris_rid}` LIMIT 100")
-
     assert iris_pdf.shape == (100, 5)
 
     pa_table = client.query_foundry_sql(

--- a/tests/test_foundry_sql_client.py
+++ b/tests/test_foundry_sql_client.py
@@ -6,146 +6,75 @@ from foundry_dev_tools.foundry_api_client import (
     BranchNotFoundError,
     DatasetHasNoSchemaError,
     DatasetNotFoundError,
-    FoundrySqlClient,
+    FoundryRestClient,
     FoundrySqlQueryClientTimedOutError,
     FoundrySqlQueryFailedError,
     FoundrySqlSerializationFormatNotImplementedError,
 )
 
 
-def mock_initiate_session(
-    requests_mock: Mocker,
-    session_id="96bbd062-b5c1-428d-95f3-739683955ff8",
-    session_auth_token="Zu+eMIE1Unlr7vvgZ2kHkg==",  # noqa: S107
-):
-    requests_mock.post(
-        url=ANY,
-        status_code=200,
-        json={"sessionId": session_id, "sessionAuthToken": session_auth_token},
-    )
-
-
-@pytest.fixture()
-def sql_client(requests_mock: Mocker):
-    mock_initiate_session(requests_mock)
-    return FoundrySqlClient()
-
-
-def test_session_is_established(
-    requests_mock: Mocker,
-):
-    mock_initiate_session(
-        requests_mock,
-        "96bbd062-b5c1-428d-95f3-739683955ff8",
-        "Zu+eMIE1Unlr7vvgZ2kHkg==",
-    )
-
-    client = FoundrySqlClient()
-    assert client.session_auth_token == "Zu+eMIE1Unlr7vvgZ2kHkg=="  # noqa: S105
-    assert client.session_id == "96bbd062-b5c1-428d-95f3-739683955ff8"
-    assert client._headers["Session-Authorization"] == "Zu+eMIE1Unlr7vvgZ2kHkg=="
-
-
-def test_prepare_and_execute(requests_mock: Mocker, sql_client):
+def test_execute_query(requests_mock: Mocker):
+    client = FoundryRestClient()
     requests_mock.post(
         url=ANY,
         status_code=200,
         json={
-            "jobId": "217984f8-8a30-45a8-ba08-0e4a8c3f2e7c",
-            "status": {
-                "type": "ready",
-                "ready": {"jobId": "217984f8-8a30-45a8-ba08-0e4a8c3f2e7c"},
-            },
-            "statementId": "de928220-61c1-4aa7-acd0-91e5b9d4ae95",
+            "queryId": "b343c6c1-a35f-4cc5-88e8-041c84974de6",
+            "status": {"ready": {}, "type": "ready"},
         },
     )
-    response_dict = sql_client._prepare_and_execute("SELECT * FROM `blub`")
+    response_dict = client._execute_fsql_query("SELECT * FROM `blub`")
     assert response_dict == {
-        "jobId": "217984f8-8a30-45a8-ba08-0e4a8c3f2e7c",
-        "status": {
-            "type": "ready",
-            "ready": {"jobId": "217984f8-8a30-45a8-ba08-0e4a8c3f2e7c"},
-        },
-        "statementId": "de928220-61c1-4aa7-acd0-91e5b9d4ae95",
+        "queryId": "b343c6c1-a35f-4cc5-88e8-041c84974de6",
+        "status": {"ready": {}, "type": "ready"},
     }
 
 
-def test_poll_for_query_completion(requests_mock: Mocker, sql_client):
-    requests_mock.post(
-        url=ANY,
-        status_code=200,
-        json={
-            "status": {
-                "type": "ready",
-                "ready": {"jobId": "2c1d6597-77ea-41ac-9651-b86e19799800"},
-            }
-        },
-    )
-
-    sql_client._poll_for_query_completion(
-        {
-            "jobId": "2c1d6597-77ea-41ac-9651-b86e19799800",
-            "status": {
-                "type": "running",
-                "running": {"jobId": "2c1d6597-77ea-41ac-9651-b86e19799800"},
-            },
-            "statementId": "57977172-8a57-4f62-91d1-094c35c0a78b",
-        }
-    )
-
-
-def test_poll_for_query_completion_timeout(mocker, requests_mock: Mocker, sql_client):
+def test_poll_for_query_completion_timeout(mocker, requests_mock: Mocker):
     mocker.patch("time.sleep")  # we do not want to wait 500 ms in a test ;)
 
-    requests_mock.post(
+    requests_mock.get(
         url=ANY,
         status_code=200,
         json={
-            "jobId": "2c1d6597-77ea-41ac-9651-b86e19799800",
-            "status": {
-                "type": "running",
-                "running": {"jobId": "2c1d6597-77ea-41ac-9651-b86e19799800"},
-            },
-            "statementId": "57977172-8a57-4f62-91d1-094c35c0a78b",
+            "queryId": "26f444dc-822d-4be7-9c8f-3be52779bea5",
+            "status": {"running": {}, "type": "running"},
         },
     )
 
+    client = FoundryRestClient()
     with pytest.raises(FoundrySqlQueryClientTimedOutError):
-        sql_client._poll_for_query_completion(
+        client._poll_fsql_query_status(
             {
-                "jobId": "2c1d6597-77ea-41ac-9651-b86e19799800",
-                "status": {
-                    "type": "running",
-                    "running": {"jobId": "2c1d6597-77ea-41ac-9651-b86e19799800"},
-                },
-                "statementId": "57977172-8a57-4f62-91d1-094c35c0a78b",
+                "queryId": "26f444dc-822d-4be7-9c8f-3be52779bea5",
+                "status": {"running": {}, "type": "running"},
             },
             0.001,
         )
 
 
-def test_non_arrow_format_throws_exception(requests_mock: Mocker, sql_client):
+def test_non_arrow_format_throws_exception(requests_mock: Mocker):
     response_data = b'S{"metadata":{"computedTime":1627978857810,"resultComputationMetadata":{"submitTimeMillis":1627978856578,"startTimeMillis":1627978856580,"finishResolveDataFrameTimeMillis":1627978857302,"finishTimeMillis":1627978857763,"estimatedResultSizeOnHeapInBytes":32296,"cacheType":"NO_CACHE","initialDataframeResolutionType":"BUILT_INITIAL_SPARK_SET_AND_DF","complexDataframeResolutionType":"NO_COMPLEX_TRANSFORMATIONS","setDescription":{"type":"sql","parentsByParam":{"/Global/Foundry Operations/Foundry Support/iris-167312679":{"type":"initialwithtransaction","identifier":"ri.foundry.main.dataset.14703427-09ab-4c9c-b036-6926b34d150b:master","transaction":"ri.foundry.main.transaction.0000003a-a437-fec8-95b1-0872dc6a0991","schemaId":"00000003-d596-797c-9663-e8970c07d296","viewMetadataId":null,"maybeStartTransaction":"ri.foundry.main.transaction.0000003a-a437-fec8-95b1-0872dc6a0991"}},"sqlQuery":"SELECT * FROM ${/Global/Foundry Operations/Foundry Support/iris-167312679}"},"queryMetricMetadata":{"queueSubmittedTimeMillis":1627978856263,"wasPunted":false},"traceId":"65a45518d71a3922","saveTraceId":"1ae3ca3cbb85ca39","latitudeQueryDescription":{"humanReadableDescription":null,"metadata":{"Skip the non-contour backend cache":"false","UserId":"3c8fbda5-686e-4fcb-ad52-d95e4281d99f","GraphId":"","NodeId":"","RefRid":"","SourceId":"foundry-sql-server"},"sourceMetadata":{"graphId":null,"nodeId":null,"refRid":null,"refParentRid":null,"sourceId":"foundry-sql-server","sparkReporterOwningRid":null,"resourceManagementAttributionRid":null,"userId":"3c8fbda5-686e-4fcb-ad52-d95e4281d99f","datasetRids":["ri.foundry.main.dataset.14703427-09ab-4c9c-b036-6926b34d150b"],"lsdHash":"01b919b1f5528a8895d161da41b4d55d","lsdHashWithMetadataScrubbed":"9c4501650954bcc765e2c8b6fd2920c5","lsdHashWithDatasetAndMetadataScrubbed":"38d9cc6b14c2d21ac287b53050ebc9aa","unresolvedLsdHash":null,"unresolvedLsdHashWithMetadataScrubbed":null,"unresolvedLsdHashWithDatasetAndMetadataScrubbed":null},"trimmedDatasetRids":[],"requestTraceId":"b2a7f6e4f8e68d97","requestTimeMillis":1627978856150},"backendMetricsTag":"foundrysqlserver-contour-backend-foundry-0","backendGroupMetricsTag":"foundry-sql-server-modules","groupProducerMetricsTag":"foundrysqlserver","numberOfTasks":null,"numberOfStages":null},"computedVersion":"9.206.0","warningMessage":null,"resultId":null,"rowCount":150,"columns":["id","is_setosa","species","sepal_length","sepal_width","petal_length","petal_width"],"columnTypes":[{"type":"INTEGER","name":"id","nullable":true,"customMetadata":{}},{"type":"INTEGER","name":"is_setosa","nullable":true,"customMetadata":{}},{"type":"STRING","name":"species","nullable":true,"customMetadata":{}},{"type":"DOUBLE","name":"sepal_length","nullable":true,"customMetadata":{}},{"type":"DOUBLE","name":"sepal_width","nullable":true,"customMetadata":{}},{"type":"DOUBLE","name":"petal_length","nullable":true,"customMetadata":{}},{"type":"DOUBLE","name":"petal_width","nullable":true,"customMetadata":{}}]},"rows":[[1,1,"setosa",5.1,3.5,1.4,0.2],[2,1,"setosa",4.9,3.0,1.4,0.2],[3,1,"setosa",4.7,3.2,1.3,0.2],[4,1,"setosa",4.6,3.1,1.5,0.2],[5,1,"setosa",5.0,3.6,1.4,0.2],[6,1,"setosa",5.0,3.4,1.5,0.2],[7,1,"setosa",4.4,2.9,1.4,0.2],[8,1,"setosa",5.4,3.7,1.5,0.2],[9,1,"setosa",4.8,3.4,1.6,0.2],[10,1,"setosa",5.8,4.0,1.2,0.2],[11,1,"setosa",5.4,3.4,1.7,0.2],[12,1,"setosa",4.6,3.6,1.0,0.2],[13,1,"setosa",4.8,3.4,1.9,0.2],[14,1,"setosa",5.0,3.0,1.6,0.2],[15,1,"setosa",5.2,3.5,1.5,0.2],[16,1,"setosa",5.2,3.4,1.4,0.2],[17,1,"setosa",4.7,3.2,1.6,0.2],[18,1,"setosa",4.8,3.1,1.6,0.2],[19,1,"setosa",5.5,4.2,1.4,0.2],[20,1,"setosa",4.9,3.1,1.5,0.2],[21,1,"setosa",5.0,3.2,1.2,0.2],[22,1,"setosa",5.5,3.5,1.3,0.2],[23,1,"setosa",4.4,3.0,1.3,0.2],[24,1,"setosa",5.1,3.4,1.5,0.2],[25,1,"setosa",4.4,3.2,1.3,0.2],[26,1,"setosa",5.1,3.8,1.6,0.2],[27,1,"setosa",4.6,3.2,1.4,0.2],[28,1,"setosa",5.3,3.7,1.5,0.2],[29,1,"setosa",5.0,3.3,1.4,0.2],[30,0,"versicolor",6.4,3.2,4.5,1.5],[31,0,"versicolor",6.9,3.1,4.9,1.5],[32,0,"versicolor",6.5,2.8,4.6,1.5],[33,0,"versicolor",5.9,3.0,4.2,1.5],[34,0,"versicolor",5.6,3.0,4.5,1.5],[35,0,"versicolor",6.2,2.2,4.5,1.5],[36,0,"versicolor",6.3,2.5,4.9,1.5],[37,0,"versicolor",6.0,2.9,4.5,1.5],[38,0,"versicolor",5.4,3.0,4.5,1.5],[39,0,"versicolor",6.7,3.1,4.7,1.5],[40,0,"virginica",6.0,2.2,5.0,1.5],[41,0,"virginica",6.3,2.8,5.1,1.5],[42,0,"versicolor",5.9,3.2,4.8,1.8],[43,0,"virginica",6.3,2.9,5.6,1.8],[44,0,"virginica",7.3,2.9,6.3,1.8],[45,0,"virginica",6.7,2.5,5.8,1.8],[46,0,"virginica",6.5,3.0,5.5,1.8],[47,0,"virginica",6.3,2.7,4.9,1.8],[48,0,"virginica",7.2,3.2,6.0,1.8],[49,0,"virginica",6.2,2.8,4.8,1.8],[50,0,"virginica",6.1,3.0,4.9,1.8],[51,0,"virginica",6.4,3.1,5.5,1.8],[52,0,"virginica",6.0,3.0,4.8,1.8],[53,0,"virginica",5.9,3.0,5.1,1.8],[54,0,"versicolor",5.5,2.3,4.0,1.3],[55,0,"versicolor",5.7,2.8,4.5,1.3],[56,0,"versicolor",6.6,2.9,4.6,1.3],[57,0,"versicolor",5.6,2.9,3.6,1.3],[58,0,"versicolor",6.1,2.8,4.0,1.3],[59,0,"versicolor",6.4,2.9,4.3,1.3],[60,0,"versicolor",6.3,2.3,4.4,1.3],[61,0,"versicolor",5.6,3.0,4.1,1.3],[62,0,"versicolor",5.5,2.5,4.0,1.3],[63,0,"versicolor",5.6,2.7,4.2,1.3],[64,0,"versicolor",5.7,2.9,4.2,1.3],[65,0,"versicolor",6.2,2.9,4.3,1.3],[66,0,"versicolor",5.7,2.8,4.1,1.3],[67,0,"versicolor",7.0,3.2,4.7,1.4],[68,0,"versicolor",5.2,2.7,3.9,1.4],[69,0,"versicolor",6.1,2.9,4.7,1.4],[70,0,"versicolor",6.7,3.1,4.4,1.4],[71,0,"versicolor",6.6,3.0,4.4,1.4],[72,0,"versicolor",6.8,2.8,4.8,1.4],[73,0,"versicolor",6.1,3.0,4.6,1.4],[74,0,"virginica",6.1,2.6,5.6,1.4],[75,0,"versicolor",4.9,2.4,3.3,1.0],[76,0,"versicolor",5.0,2.0,3.5,1.0],[77,0,"versicolor",6.0,2.2,4.0,1.0],[78,0,"versicolor",5.8,2.7,4.1,1.0],[79,0,"versicolor",5.7,2.6,3.5,1.0],[80,0,"versicolor",5.5,2.4,3.7,1.0],[81,0,"versicolor",5.0,2.3,3.3,1.0],[82,0,"virginica",6.4,3.2,5.3,2.3],[83,0,"virginica",7.7,2.6,6.9,2.3],[84,0,"virginica",6.9,3.2,5.7,2.3],[85,0,"virginica",7.7,3.0,6.1,2.3],[86,0,"virginica",6.9,3.1,5.1,2.3],[87,0,"virginica",6.8,3.2,5.9,2.3],[88,0,"virginica",6.7,3.0,5.2,2.3],[89,0,"virginica",6.2,3.4,5.4,2.3],[90,1,"setosa",5.4,3.9,1.7,0.4],[91,1,"setosa",5.7,4.4,1.5,0.4],[92,1,"setosa",5.4,3.9,1.3,0.4],[93,1,"setosa",5.1,3.7,1.5,0.4],[94,1,"setosa",5.0,3.4,1.6,0.4],[95,1,"setosa",5.4,3.4,1.5,0.4],[96,1,"setosa",5.1,3.8,1.9,0.4],[97,1,"setosa",4.6,3.4,1.4,0.3],[98,1,"setosa",5.1,3.5,1.4,0.3],[99,1,"setosa",5.7,3.8,1.7,0.3],[100,1,"setosa",5.1,3.8,1.5,0.3],[101,1,"setosa",5.0,3.5,1.3,0.3],[102,1,"setosa",4.5,2.3,1.3,0.3],[103,1,"setosa",4.8,3.0,1.4,0.3],[104,0,"virginica",6.5,3.2,5.1,2.0],[105,0,"virginica",5.7,2.5,5.0,2.0],[106,0,"virginica",5.6,2.8,4.9,2.0],[107,0,"virginica",7.7,2.8,6.7,2.0],[108,0,"virginica",7.9,3.8,6.4,2.0],[109,0,"virginica",6.5,3.0,5.2,2.0],[110,0,"versicolor",6.1,2.8,4.7,1.2],[111,0,"versicolor",5.8,2.7,3.9,1.2],[112,0,"versicolor",5.5,2.6,4.4,1.2],[113,0,"versicolor",5.8,2.6,4.0,1.2],[114,0,"versicolor",5.7,3.0,4.2,1.2],[115,0,"virginica",5.8,2.7,5.1,1.9],[116,0,"virginica",6.4,2.7,5.3,1.9],[117,0,"virginica",7.4,2.8,6.1,1.9],[118,0,"virginica",5.8,2.7,5.1,1.9],[119,0,"virginica",6.3,2.5,5.0,1.9],[120,0,"virginica",7.1,3.0,5.9,2.1],[121,0,"virginica",7.6,3.0,6.6,2.1],[122,0,"virginica",6.8,3.0,5.5,2.1],[123,0,"virginica",6.7,3.3,5.7,2.1],[124,0,"virginica",6.4,2.8,5.6,2.1],[125,0,"virginica",6.9,3.1,5.4,2.1],[126,1,"setosa",4.9,3.1,1.5,0.1],[127,1,"setosa",4.8,3.0,1.4,0.1],[128,1,"setosa",4.3,3.0,1.1,0.1],[129,1,"setosa",5.2,4.1,1.5,0.1],[130,1,"setosa",4.9,3.6,1.4,0.1],[131,0,"versicolor",6.3,3.3,4.7,1.6],[132,0,"versicolor",6.0,2.7,5.1,1.6],[133,0,"versicolor",6.0,3.4,4.5,1.6],[134,0,"virginica",7.2,3.0,5.8,1.6],[135,0,"versicolor",5.6,2.5,3.9,1.1],[136,0,"versicolor",5.5,2.4,3.8,1.1],[137,0,"versicolor",5.1,2.5,3.0,1.1],[138,0,"virginica",6.3,3.3,6.0,2.5],[139,0,"virginica",7.2,3.6,6.1,2.5],[140,0,"virginica",6.7,3.3,5.7,2.5],[141,0,"virginica",5.8,2.8,5.1,2.4],[142,0,"virginica",6.3,3.4,5.6,2.4],[143,0,"virginica",6.7,3.1,5.6,2.4],[144,0,"virginica",6.5,3.0,5.8,2.2],[145,0,"virginica",7.7,3.8,6.7,2.2],[146,0,"virginica",6.4,2.8,5.6,2.2],[147,0,"versicolor",6.7,3.0,5.0,1.7],[148,0,"virginica",4.9,2.5,4.5,1.7],[149,1,"setosa",5.0,3.5,1.6,0.6],[150,1,"setosa",5.1,3.3,1.7,0.5]]}'  # noqa: E501
 
-    requests_mock.post(url=ANY, content=response_data)
-
+    requests_mock.get(url=ANY, content=response_data)
+    client = FoundryRestClient()
     with pytest.raises(FoundrySqlSerializationFormatNotImplementedError):
-        sql_client._read_results_arrow("statement-id")
+        client._read_fsql_query_results_arrow("queryId")
 
 
-def test_read_arrow_optional_polars(requests_mock: Mocker, sql_client):
+def test_read_arrow_optional_polars(requests_mock: Mocker):
     response_data = b'A\xff\xff\xff\xff\xb0\x01\x00\x00\x10\x00\x00\x00\x00\x00\n\x00\x0e\x00\x06\x00\r\x00\x08\x00\n\x00\x00\x00\x00\x00\x04\x00\x10\x00\x00\x00\x00\x01\n\x00\x0c\x00\x00\x00\x08\x00\x04\x00\n\x00\x00\x00\x08\x00\x00\x00,\x01\x00\x00\x01\x00\x00\x00\x0c\x00\x00\x00\x08\x00\x0c\x00\x08\x00\x04\x00\x08\x00\x00\x00\x08\x00\x00\x00\x00\x01\x00\x00\xf5\x00\x00\x00{"computedTime":1627977691184,"resultComputationMetadata":null,"computedVersion":null,"warningMessage":null,"resultId":null,"rowCount":null,"columns":["MATNR"],"columnTypes":[{"type":"STRING","name":"MATNR","nullable":true,"customMetadata":{}}]}\x00\x00\x00\x08\x00\x00\x00metadata\x00\x00\x00\x00\x01\x00\x00\x00\x18\x00\x00\x00\x00\x00\x12\x00\x18\x00\x14\x00\x13\x00\x12\x00\x0c\x00\x00\x00\x08\x00\x04\x00\x12\x00\x00\x00\x14\x00\x00\x00\x14\x00\x00\x00\x18\x00\x00\x00\x00\x00\x05\x01\x14\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x04\x00\x04\x00\x04\x00\x00\x00\x05\x00\x00\x00MATNR\x00\x00\x00\x00\x00\x00\x00\xff\xff\xff\xff\x98\x00\x00\x00\x14\x00\x00\x00\x00\x00\x00\x00\x0c\x00\x16\x00\x0e\x00\x15\x00\x10\x00\x04\x00\x0c\x00\x00\x00 \x00\x00\x00\x00\x00\x00\x00\x00\x00\x04\x00\x10\x00\x00\x00\x00\x03\n\x00\x18\x00\x0c\x00\x08\x00\x04\x00\n\x00\x00\x00\x14\x00\x00\x00H\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x08\x00\x00\x00\x00\x00\x00\x00\x08\x00\x00\x00\x00\x00\x00\x00\x10\x00\x00\x00\x00\x00\x00\x00\x10\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x10\x00\x00\x0000062106-RNA-5UG\xff\xff\xff\xff\x00\x00\x00\x00E'  # noqa: E501
+    client = FoundryRestClient()
+    requests_mock.get(url=ANY, content=response_data)
 
-    requests_mock.post(url=ANY, content=response_data)
-
-    arrow_stream = sql_client._read_results_arrow("statement-id")
+    arrow_stream = client._read_fsql_query_results_arrow("queryId")
     pdf = arrow_stream.read_pandas()
     assert pdf.shape == (1, 1)
 
     try:
         import polars as pl
 
-        arrow_stream = sql_client._read_results_arrow("statement-id")
+        arrow_stream = client._read_fsql_query_results_arrow("queryId")
         pa_table = arrow_stream.read_all()
         df = pl.from_arrow(pa_table)
         assert df.shape == (1, 1)
@@ -155,58 +84,32 @@ def test_read_arrow_optional_polars(requests_mock: Mocker, sql_client):
 
 @pytest.mark.integration()
 def test_smoke(iris_dataset):
-    sql_client = FoundrySqlClient()
-    one_row_one_column = sql_client.query(
+    client = FoundryRestClient()
+    one_row_one_column = client._query_fsql(
         f"SELECT sepal_width FROM `{iris_dataset[1]}` LIMIT 1"
     )
     assert one_row_one_column.shape == (1, 1)
 
 
 @pytest.mark.integration()
-def test_legacy_fallback(mocker, iris_dataset, client):
-    from foundry_dev_tools.foundry_api_client import FoundryRestClient as frc_class
-
-    spy = mocker.spy(frc_class, "query_foundry_sql_legacy")
-    # The query does require SQL compute.
-    # Queries which contain aggregate, join, order by, and filter predicates are not direct read eligible.
-    # and unfortunately returned in JSON Format, not ARROW
-    iris = client.query_foundry_sql(
-        f"SELECT * FROM `{iris_dataset[1]}` order by sepal_width LIMIT 100"
-    )
-    assert iris.shape == (100, 5)
-    spy.assert_called()
-
-    spy.reset_mock()
-    import sys
-
-    pyarrow = sys.modules["pyarrow"]
-    sys.modules["pyarrow"] = None
-
-    iris = client.query_foundry_sql(f"SELECT * FROM `{iris_dataset[1]}`")
-    assert iris.shape == (150, 5)
-    spy.assert_called()
-
-    sys.modules["pyarrow"] = pyarrow
-
-
-@pytest.mark.integration()
 def test_exceptions(iris_dataset, iris_no_schema_dataset):
-    sql_client1 = FoundrySqlClient(branch="doesNotExist")
+    client = FoundryRestClient()
     with pytest.raises(BranchNotFoundError) as exc:
-        sql_client1.query(f"SELECT * FROM `{iris_dataset[1]}` LIMIT 100")
+        client._query_fsql(
+            f"SELECT * FROM `{iris_dataset[1]}` LIMIT 100", branch="doesNotExist"
+        )
     assert exc.value.dataset_rid == iris_dataset[0]
     assert exc.value.branch == "doesNotExist"
 
-    client = FoundrySqlClient()
     with pytest.raises(DatasetHasNoSchemaError):
-        client.query(f"SELECT * FROM `{iris_no_schema_dataset[1]}` LIMIT 100")
+        client._query_fsql(f"SELECT * FROM `{iris_no_schema_dataset[1]}` LIMIT 100")
 
     with pytest.raises(DatasetNotFoundError) as exc:
-        client.query("SELECT * FROM `/namespace1/does-not_exists/` LIMIT 100")
+        client._query_fsql("SELECT * FROM `/namespace1/does-not_exists/` LIMIT 100")
     assert exc.value.dataset_rid == "/namespace1/does-not_exists/"
 
     with pytest.raises(BranchNotFoundError) as exc:
-        client.query(
+        client._query_fsql(
             "SELECT * FROM `ri.foundry.main.dataset.1337fb9d-1234-43c7-b83f-768f2b843b94` LIMIT 100"
         )
     assert (
@@ -216,4 +119,18 @@ def test_exceptions(iris_dataset, iris_no_schema_dataset):
     assert exc.value.branch == "master"
 
     with pytest.raises(FoundrySqlQueryFailedError):
-        client.query(f"SELECT foo, bar, FROM `{iris_dataset[1]}` LIMIT 100")
+        client._query_fsql(f"SELECT foo, bar, FROM `{iris_dataset[1]}` LIMIT 100")
+
+
+def test_legacy_fallback(mocker):
+    mocker.patch(
+        "foundry_dev_tools.foundry_api_client.FoundryRestClient._query_fsql"
+    ).side_effect = FoundrySqlSerializationFormatNotImplementedError()
+    query_foundry_sql_legacy_spy = mocker.patch(
+        "foundry_dev_tools.foundry_api_client.FoundryRestClient.query_foundry_sql_legacy"
+    )
+    client = FoundryRestClient()
+
+    client.query_foundry_sql("SELECT * FROM `test`")
+
+    query_foundry_sql_legacy_spy.assert_called()


### PR DESCRIPTION
# Summary

* Move to ARROW_V1 which consistently returns arrow format
* Harmonize sql function signatures to query, branch, return_type, timeout
* remove FoundrySqlClient class since no session state needs to be handled anymore

# Checklist

- [x] You agree with our [CLA](https://gist.githubusercontent.com/emdgroup-admin/16cc45ea4315c2ef29eb9d9afc36fcf5/raw/abb9c91f15278a62b9ac3e66144bcd27fa9485c2/CLA.md)
- [x] Included tests (or is not applicable).
- [ ] Updated [documentation](https://emdgroup.github.io/foundry-dev-tools/) (or is not applicable).
- [x] Used [pre-commit hooks](https://emdgroup.github.io/foundry-dev-tools/develop.html#pre-commit-hooks-formatting) to format and lint the code.
