### PR TITLE
fix dataset output at the end of the build

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
     args: ['--fix=lf']  # replace 'auto' with 'lf' to enforce Linux/Mac line endings or 'crlf' for Windows
 - repo: https://github.com/charliermarsh/ruff-pre-commit
   # Ruff version.
-  rev: 'v0.0.270'
+  rev: 'v0.0.271'
   hooks:
     - id: ruff
       args: ["--fix","--exit-non-zero-on-fix","--show-fixes"]

--- a/src/foundry_dev_tools/cli/build.py
+++ b/src/foundry_dev_tools/cli/build.py
@@ -9,7 +9,7 @@ import time
 from datetime import datetime
 from pathlib import Path
 from typing import List
-from urllib.parse import urlparse
+from urllib.parse import quote_plus, urlparse
 
 import click
 import inquirer
@@ -281,7 +281,7 @@ def build_cli(transform):  # noqa: PLR0915
             retries += 1
             return _finish(_req(), exit_code, retries)
         build_rid = _find_rid(response["allJobs"], name="Build initialization")
-        branch = ref_name[11:]
+        branch = quote_plus(ref_name[11:])
         if build_id := _get_started_build(response, build_rid):
             print_horizontal_line(print_handler=rprint)
             rprint(f"Build status: {response['buildStatus']}")

--- a/src/foundry_dev_tools/foundry_api_client.py
+++ b/src/foundry_dev_tools/foundry_api_client.py
@@ -1868,6 +1868,25 @@ class FoundryRestClient:
         _raise_for_status_verbose(response)
         return response.json()
 
+    def get_job_report(self, job_rid: str) -> dict:
+        """Get the report for a job.
+
+        Args:
+            job_rid (str): the job RID
+
+        Returns:
+            dict: the job report response
+
+        """
+        response = _request(
+            "GET",
+            f"{self.builds2}/info/jobs3/{job_rid}",
+            headers=self._headers(),
+            verify=self._verify(),
+        )
+        _raise_for_status_verbose(response)
+        return response.json()
+
     def _execute_fsql_query(self, query: str, branch="master", timeout=600) -> dict:
         response = _request(
             "POST",

--- a/tests/foundry_mock_client.py
+++ b/tests/foundry_mock_client.py
@@ -573,7 +573,7 @@ class MockFoundryRestClient(FoundryRestClient):
     @staticmethod
     def _generate_resource_identifier(resource_type="ri.foundry.main.dataset"):
         flake = timeflake.random().uuid
-        return f"{resource_type}.{str(flake)}"
+        return f"{resource_type}.{flake!s}"
 
     @staticmethod
     def _current_datetime():

--- a/tests/test_cli_build.py
+++ b/tests/test_cli_build.py
@@ -325,8 +325,16 @@ class WebSocketMock:
     ),
 )
 @mock.patch("foundry_dev_tools.cli.build.is_transform_file", return_value=True)
+@mock.patch(
+    "foundry_dev_tools.foundry_api_client.FoundryRestClient.get_job_report",
+    return_value={
+        "jobResults": {
+            "ri.foundry.main.dataset.81d943dd-8b84-46ba-b720-5e227de8bb6a": {}
+        }
+    },
+)
 @mock.patch("foundry_dev_tools.utils.misc.print_horizontal_line")
-def test_build(a, b, c, d, e, f, caplog):
+def test_build(a, b, c, d, e, f, g, caplog):
     with PatchConfig(
         initial_config_overwrite={
             "jwt": "test_build_jwt",
@@ -373,10 +381,9 @@ def test_build(a, b, c, d, e, f, caplog):
 
         COMPL = "Spark Job Completed."
         assert output[output.index(COMPL) + len(COMPL) :] == (
-            "Build status: SUCCEEDEDLink to the foundry build: https://test_build.url/workspace/data-integration/job"
-            "-tracker/builds/ri.foundry.main.build.0e7ca16b-49f1-4b2d-953e-21b18bc7c560The resulting dataset for tra"
-            "nsforms-python/src/myproject/datasets/examples.py:https://test_build.url/workspace/data-integration/dat"
-            "aset/preview/ri.foundry.main.dataset.81d943dd-8b84-46ba-b720-5e227de8bb6a/master"
+            "Build status: SUCCEEDEDLink to the foundry build: https://test_build.url/workspace/data-integration/job-tr"
+            "acker/builds/ri.foundry.main.build.0e7ca16b-49f1-4b2d-953e-21b18bc7c560The resulting dataset(s):https://te"
+            "st_build.url/workspace/data-integration/dataset/preview/ri.foundry.main.dataset.81d943dd-8b84-46ba-b720-5e227de8bb6a/master"
         )
         assert result.exit_code == 0
 

--- a/tests/test_cli_build.py
+++ b/tests/test_cli_build.py
@@ -57,7 +57,7 @@ BUILD_LOG_RESPONSE = {
             "parameters": {
                 "repositoryTarget": {
                     "repositoryRid": "ri.stemma.main.repository.a0b5defa-82d9-4959-bdef-28e02e00cd48",
-                    "refName": "refs/heads/master",
+                    "refName": "refs/heads/dev/branch",
                     "commitHash": "52bdea68c6538acc79eb03bc33292314f97551f4",
                 }
             },
@@ -298,7 +298,7 @@ class WebSocketMock:
     "foundry_dev_tools.cli.build.get_repo",
     return_value=(
         "ri.stemma.main.repository.a0b5defa-82d9-4959-bdef-28e02e00cd48",
-        "refs/heads/master",
+        "refs/heads/dev/branch",
         "52bdea68c6538acc79eb03bc33292314f97551f4",
         Path.cwd(),
     ),
@@ -383,7 +383,7 @@ def test_build(a, b, c, d, e, f, g, caplog):
         assert output[output.index(COMPL) + len(COMPL) :] == (
             "Build status: SUCCEEDEDLink to the foundry build: https://test_build.url/workspace/data-integration/job-tr"
             "acker/builds/ri.foundry.main.build.0e7ca16b-49f1-4b2d-953e-21b18bc7c560The resulting dataset(s):https://te"
-            "st_build.url/workspace/data-integration/dataset/preview/ri.foundry.main.dataset.81d943dd-8b84-46ba-b720-5e227de8bb6a/master"
+            "st_build.url/workspace/data-integration/dataset/preview/ri.foundry.main.dataset.81d943dd-8b84-46ba-b720-5e227de8bb6a/dev%2Fbranch"
         )
         assert result.exit_code == 0
 


### PR DESCRIPTION
# Summary

<!-- summary of your changes -->
- Now uses the dataset rid's from the job report


# Checklist

- [x] You agree with our [CLA](https://gist.githubusercontent.com/emdgroup-admin/16cc45ea4315c2ef29eb9d9afc36fcf5/raw/abb9c91f15278a62b9ac3e66144bcd27fa9485c2/CLA.md)
- [x] Included tests (or is not applicable).
- [x] Updated [documentation](https://emdgroup.github.io/foundry-dev-tools/) (or is not applicable).
- [x] Used [pre-commit hooks](https://emdgroup.github.io/foundry-dev-tools/develop.html#pre-commit-hooks-formatting) to format and lint the code.
