### PR TITLE
use absolute python path in aws config

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning].
 - typos in docs (#30)
 - pandas test (#31)
 - windows specific test errors (#33)
+- use absolute python path in aws config (#35)
 
 ## [1.2] - 2023-07-05
 

--- a/src/foundry_dev_tools/cli/s3.py
+++ b/src/foundry_dev_tools/cli/s3.py
@@ -45,9 +45,9 @@ def s3_cli_init():
                 sys.exit(1)
             cp.remove_section("profile foundry")
     credential_process = (
-        'cmd /C "fdt s3 auth 2>CON"'
+        f'cmd /C "{sys.executable} -m foundry_dev_tools.cli.main s3 auth 2>CON"'
         if platform.system() == "Windows"
-        else "sh -c 'fdt s3 auth 2>/dev/tty'"
+        else f"sh -c '{sys.executable} -m foundry_dev_tools.cli.main s3 auth 2>/dev/tty'"
     )
     cp.read_dict(
         {


### PR DESCRIPTION
# Summary
use absolute python path in aws config -> environment independent

# Checklist

- [x] You agree with our [CLA](https://gist.githubusercontent.com/emdgroup-admin/16cc45ea4315c2ef29eb9d9afc36fcf5/raw/abb9c91f15278a62b9ac3e66144bcd27fa9485c2/CLA.md)
- [x] Included tests (or is not applicable).
- [x] Updated [documentation](https://emdgroup.github.io/foundry-dev-tools/) (or is not applicable).
- [x] Used [pre-commit hooks](https://emdgroup.github.io/foundry-dev-tools/develop.html#pre-commit-hooks-formatting) to format and lint the code.
