### PR TITLE
fix version in UA

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog],
 and this project adheres to [Semantic Versioning].
 
+## [1.3.2] - 2023-10-31
+
+## Fixed
+
+- version in UA (#39)
+
 ## [1.3.1] - 2023-10-30
 
 ### Changed
@@ -165,7 +171,8 @@ and this project adheres to [Semantic Versioning].
 [Keep a Changelog]: https://keepachangelog.com/en/1.0.0/
 [Semantic Versioning]: https://semver.org/spec/v2.0.0.html
 
-[1.3]: https://github.com/emdgroup/foundry-dev-tools/compare/v1.3...v1.3.1
+[1.3.2]: https://github.com/emdgroup/foundry-dev-tools/compare/v1.3.1...v1.3.2
+[1.3.1]: https://github.com/emdgroup/foundry-dev-tools/compare/v1.3...v1.3.1
 [1.3]: https://github.com/emdgroup/foundry-dev-tools/compare/v1.2...v1.3
 [1.2]: https://github.com/emdgroup/foundry-dev-tools/compare/v1.1...v1.2
 [1.1]: https://github.com/emdgroup/foundry-dev-tools/compare/v1.0.12...v1.1

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -120,7 +120,7 @@ copyright = "2023, (Merck KGaA, Darmstadt, Germany)"
 # If you don`t need the separation provided between version and release,
 # just set them both to the same value.
 try:
-    from foundry_dev_tools import __version__ as version
+    from foundry_dev_tools.__about__ import __version__ as version
 except ImportError:
     version = ""
 

--- a/src/foundry_dev_tools/__about__.py
+++ b/src/foundry_dev_tools/__about__.py
@@ -1,0 +1,7 @@
+"""FoundryDevTools version."""
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    __version__ = version(__name__.split(".")[0])
+except PackageNotFoundError:  # pragma: no cover
+    __version__ = "unknown"

--- a/src/foundry_dev_tools/__init__.py
+++ b/src/foundry_dev_tools/__init__.py
@@ -1,10 +1,5 @@
 """Foundry Clients developed at Merck KGaA, Darmstadt, Germany."""
-from importlib.metadata import PackageNotFoundError, version
-
-try:
-    __version__ = version(__name__)
-except PackageNotFoundError:  # pragma: no cover
-    __version__ = "unknown"
+from .__about__ import __version__
 from .cached_foundry_client import CachedFoundryClient
 from .config import FOUNDRY_DEV_TOOLS_DIRECTORY, INITIAL_CONFIG, Configuration
 from .foundry_api_client import FoundryRestClient

--- a/src/foundry_dev_tools/foundry_api_client.py
+++ b/src/foundry_dev_tools/foundry_api_client.py
@@ -21,7 +21,6 @@ import time
 import warnings
 from contextlib import contextmanager
 from enum import Enum, EnumMeta
-from importlib.metadata import PackageNotFoundError, version
 from itertools import repeat
 from pathlib import Path
 from typing import IO, TYPE_CHECKING, AnyStr
@@ -31,6 +30,8 @@ import palantir_oauth_client
 import requests
 
 import foundry_dev_tools.config
+
+from .__about__ import __version__
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -50,19 +51,10 @@ if platform.system() == "Darwin":
 
 LOGGER = logging.getLogger(__name__)
 
-# duplicate code from __init__.py
-# if we import __version__ from __init__.py
-# we will have a circular import
-# which may have unintended side effects
-try:
-    FDT_VERSION = version(__name__)
-except PackageNotFoundError:  # pragma: no cover
-    FDT_VERSION = "unknown"
-
 DEFAULT_REQUESTS_CONNECT_TIMEOUT = 10
 DEFAULT_HEADERS = {
     "User-Agent": requests.utils.default_user_agent(
-        f"foundry-dev-tools/{FDT_VERSION}/python-requests"
+        f"foundry-dev-tools/{__version__}/python-requests"
     ),
     "Content-Type": "application/json",
 }
@@ -2275,7 +2267,7 @@ def _get_oauth2_client_credentials_token(
     """
     headers = {
         "User-Agent": requests.utils.default_user_agent(
-            f"foundry-dev-tools/{FDT_VERSION}/python-requests"
+            f"foundry-dev-tools/{__version__}/python-requests"
         ),
         "Authorization": "Basic "
         + base64.b64encode(bytes(client_id + ":" + client_secret, "ISO-8859-1")).decode(

--- a/src/transforms/__init__.py
+++ b/src/transforms/__init__.py
@@ -1,4 +1,4 @@
 """The transforms module is a stub for the Foundry API."""
-from foundry_dev_tools import __version__
+from foundry_dev_tools.__about__ import __version__
 
 __all__ = ["__version__"]


### PR DESCRIPTION
# Summary

The user agent showed 'unknown' as the version since v1.1, this fixes this issue.

# Checklist

- [x] You agree with our [CLA](https://gist.githubusercontent.com/emdgroup-admin/16cc45ea4315c2ef29eb9d9afc36fcf5/raw/abb9c91f15278a62b9ac3e66144bcd27fa9485c2/CLA.md)
- [x] Included tests (or is not applicable).
- [x] Updated [documentation](https://emdgroup.github.io/foundry-dev-tools/) (or is not applicable).
- [x] Used [pre-commit hooks](https://emdgroup.github.io/foundry-dev-tools/develop.html#pre-commit-hooks-formatting) to format and lint the code.
