### PR TITLE
Allow to set consent flag when enabling third party application.

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog],
 and this project adheres to [Semantic Versioning].
 
+## [1.3.3] - 2023-11-02
+
+## Added
+
+- allow to set consent flag when enabling third party application. (#40)
+
 ## [1.3.2] - 2023-10-31
 
 ## Fixed
@@ -171,6 +177,7 @@ and this project adheres to [Semantic Versioning].
 [Keep a Changelog]: https://keepachangelog.com/en/1.0.0/
 [Semantic Versioning]: https://semver.org/spec/v2.0.0.html
 
+[1.3.3]: https://github.com/emdgroup/foundry-dev-tools/compare/v1.3.2...v1.3.3
 [1.3.2]: https://github.com/emdgroup/foundry-dev-tools/compare/v1.3.1...v1.3.2
 [1.3.1]: https://github.com/emdgroup/foundry-dev-tools/compare/v1.3...v1.3.1
 [1.3]: https://github.com/emdgroup/foundry-dev-tools/compare/v1.2...v1.3

--- a/src/foundry_dev_tools/foundry_api_client.py
+++ b/src/foundry_dev_tools/foundry_api_client.py
@@ -1752,7 +1752,11 @@ class FoundryRestClient:
         return response.json()
 
     def enable_third_party_application(
-        self, client_id: str, operations: list | None, resources: list | None
+        self,
+        client_id: str,
+        operations: list | None,
+        resources: list | None,
+        require_consent: bool = True,
     ) -> dict:
         """Enables Foundry Third Party application (TPA).
 
@@ -1762,6 +1766,8 @@ class FoundryRestClient:
                 if None or empty list is passed, all scopes will be activated.
             resources (list): Compass Project RID's that this TPA is allowed to access,
                 if None or empty list is passed, unrestricted access will be given.
+            require_consent (bool): When enabled, users in the org will not be prompted
+                to authorize the application themselves.
 
         Returns:
             dict:
@@ -1777,7 +1783,7 @@ class FoundryRestClient:
                     "description": None,
                     "logoUri": None,
                 },
-                "installation": {"resources": [], "operations": [], "markingIds": None},
+                "installation": {"resources": [], "operations": [], "markingIds": None, "requireConsent": True},
             }
 
         """
@@ -1788,7 +1794,11 @@ class FoundryRestClient:
         response = self._request(
             "PUT",
             f"{self.multipass}/client-installations/{client_id}",
-            json={"operations": operations, "resources": resources},
+            json={
+                "operations": operations,
+                "resources": resources,
+                "requireConsent": require_consent,
+            },
         )
         _raise_for_status_verbose(response)
         return response.json()

--- a/tests/test_multipass_tpa.py
+++ b/tests/test_multipass_tpa.py
@@ -74,7 +74,12 @@ ENABLE_RESPONSE_1 = {
         "description": None,
         "logoUri": None,
     },
-    "installation": {"resources": [], "operations": [], "markingIds": None},
+    "installation": {
+        "resources": [],
+        "operations": [],
+        "markingIds": None,
+        "requireConsent": False,
+    },
 }
 
 ENABLE_RESPONSE_2 = {
@@ -222,16 +227,21 @@ def _test_crud_inner(mocker):
     client_secret = updated_app2["clientSecret"]
 
     enabled_app = client.enable_third_party_application(
-        client_id=client_id, operations=[], resources=[]
+        client_id=client_id, operations=[], resources=[], require_consent=False
     )
     assert enabled_app["installation"]["resources"] == []
     assert enabled_app["installation"]["operations"] == []
+    assert enabled_app["installation"]["requireConsent"] is False
 
     enabled_app = client.enable_third_party_application(
-        client_id=client_id, operations=["api:read-data"], resources=[]
+        client_id=client_id,
+        operations=["api:read-data"],
+        resources=[],
+        require_consent=True,
     )
     assert enabled_app["installation"]["resources"] == []
     assert enabled_app["installation"]["operations"] == ["api:read-data"]
+    assert enabled_app["installation"]["requireConsent"] is True
 
     tpa_client = FoundryRestClient(
         config={


### PR DESCRIPTION
# Summary

Allow to set consent flag when enabling third party application.

# Checklist

- [X] You agree with our [CLA](https://gist.githubusercontent.com/emdgroup-admin/16cc45ea4315c2ef29eb9d9afc36fcf5/raw/abb9c91f15278a62b9ac3e66144bcd27fa9485c2/CLA.md)
- [X] Included tests (or is not applicable).
- [X] Updated [documentation](https://emdgroup.github.io/foundry-dev-tools/) (or is not applicable).
- [X] Used [pre-commit hooks](https://emdgroup.github.io/foundry-dev-tools/develop.html#pre-commit-hooks-formatting) to format and lint the code.
