### PR TITLE
fix: fdt build converted numbers to string

### DIFF
--- a/src/foundry_dev_tools/cli/build.py
+++ b/src/foundry_dev_tools/cli/build.py
@@ -7,6 +7,7 @@ import subprocess
 import sys
 import time
 from datetime import datetime
+from numbers import Number
 from pathlib import Path
 from typing import List
 from urllib.parse import quote_plus, urlparse
@@ -72,7 +73,7 @@ def create_log_record(log_message: str) -> logging.LogRecord:
                 lineno=0,
                 msg=f"[bold]{escape(log_data['message'])}[/bold]",
                 args=tuple(
-                    escape(str(value))
+                    value if isinstance(value, Number) else escape(str(value))
                     for key, value in log_data["unsafeParams"].items()
                     if key.startswith("param_")
                 ),

--- a/tests/test_cli_build.py
+++ b/tests/test_cli_build.py
@@ -169,7 +169,38 @@ SPARK_LOGS = [
             "message": "Output generated: %s",
             "time": "2000-01-01T00:00:00.000000Z",
             "unsafeParams": {
-                "param_0": {"key": {"value": [1]}},
+                "param_0": {"key": {"value": [1], "markup": "[/ESCAPE ME]"}},
+            },
+        }
+    ),
+    json.dumps(
+        {
+            "level": "INFO",
+            "origin": "origin",
+            "message": "Integers: %d %i,"
+            " Octal: %o,"
+            " Hex: %x %X,"
+            " Floats: %e %E %f %F %g %G,"
+            " Char: %c,"
+            " Representations: %r %s %a,"
+            " Literal %%",
+            "time": "2000-01-01T00:00:00.000000Z",
+            "unsafeParams": {
+                "param_0": 42,
+                "param_1": 42,
+                "param_2": 42,
+                "param_3": 42,
+                "param_4": 42,
+                "param_5": 42.42,
+                "param_6": 42.42,
+                "param_7": 42.42,
+                "param_8": 42.42,
+                "param_9": 42.42,
+                "param_10": 42.42,
+                "param_11": "Z",
+                "param_12": "String",
+                "param_13": "String",
+                "param_14": "String",
             },
         }
     ),
@@ -214,7 +245,40 @@ EXPECTED_SPARK_LOG_RECORDS = [
         pathname="origin",
         lineno=0,
         msg="[bold]Output generated: %s[/bold]",
-        args=("{'key': {'value': [1]}}",),
+        args=("{'key': {'value': [1], 'markup': '\\[/ESCAPE ME]'}}",),
+        exc_info=None,
+        func=None,
+        sinfo=None,
+    ),
+    logging.LogRecord(
+        name="origin",
+        level=logging.INFO,
+        pathname="origin",
+        lineno=0,
+        msg="[bold]Integers: %d %i,"
+        " Octal: %o,"
+        " Hex: %x %X,"
+        " Floats: %e %E %f %F %g %G,"
+        " Char: %c,"
+        " Representations: %r %s %a,"
+        " Literal %%[/bold]",
+        args=(
+            42,
+            42,
+            42,
+            42,
+            42,
+            42.42,
+            42.42,
+            42.42,
+            42.42,
+            42.42,
+            42.42,
+            "Z",
+            "String",
+            "String",
+            "String",
+        ),
         exc_info=None,
         func=None,
         sinfo=None,


### PR DESCRIPTION
# Summary

- only escape parameters that are not numbers, e.g. string, dictionaries, arrays

fixes #41

# Checklist

- [x] You agree with our [CLA](https://gist.githubusercontent.com/emdgroup-admin/16cc45ea4315c2ef29eb9d9afc36fcf5/raw/abb9c91f15278a62b9ac3e66144bcd27fa9485c2/CLA.md)
- [x] Included tests (or is not applicable).
- [x] Updated [documentation](https://emdgroup.github.io/foundry-dev-tools/) (or is not applicable).
- [x] Used [pre-commit hooks](https://emdgroup.github.io/foundry-dev-tools/develop.html#pre-commit-hooks-formatting) to format and lint the code.
