### PR TITLE
fix: escape non-build logs

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog],
 and this project adheres to [Semantic Versioning].
 
+## [1.3.5] - 2023-12-05
+
+## Fixed
+
+- `fdt build` escape check/build logs, previously only build job logs were escaped
+
 ## [1.3.4] - 2023-11-29
 
 ## Fixed
@@ -183,6 +189,7 @@ and this project adheres to [Semantic Versioning].
 [Keep a Changelog]: https://keepachangelog.com/en/1.0.0/
 [Semantic Versioning]: https://semver.org/spec/v2.0.0.html
 
+[1.3.4]: https://github.com/emdgroup/foundry-dev-tools/compare/v1.3.4...v1.3.5
 [1.3.4]: https://github.com/emdgroup/foundry-dev-tools/compare/v1.3.3...v1.3.4
 [1.3.3]: https://github.com/emdgroup/foundry-dev-tools/compare/v1.3.2...v1.3.3
 [1.3.2]: https://github.com/emdgroup/foundry-dev-tools/compare/v1.3.1...v1.3.2

--- a/src/foundry_dev_tools/cli/build.py
+++ b/src/foundry_dev_tools/cli/build.py
@@ -311,8 +311,11 @@ def build_cli(transform):  # noqa: PLR0915
     checks_rid = _find_rid(first_req["allJobs"], name="Checks")
     build_rid = _find_rid(first_req["allJobs"], name="Build initialization")
 
-    checks_tailer = TailHelper(rprint)
-    build_tailer = TailHelper(rprint)
+    def escape_rprint(s: str):
+        return rprint(escape(s))
+
+    checks_tailer = TailHelper(escape_rprint)
+    build_tailer = TailHelper(escape_rprint)
     if first_req["buildStatus"] in ("SUCCEEDED", "FAILED"):
         rprint(
             f"The checks and build are already finished and {first_req['buildStatus'].lower()}."

--- a/tests/test_cli_build.py
+++ b/tests/test_cli_build.py
@@ -129,6 +129,7 @@ CHECK_JOB_CUSTOM_METADATA = {
 }
 
 CHECK_LOGS = [
+    "[/ESCAPE ME]",
     "Checks...",
     "Running 1234",
     "",


### PR DESCRIPTION
# Summary

- use `escape_rprint` method instead of rprint directly
  - forgot to escape the check and build logs, only escaped the build job logs

# Checklist

- [x] You agree with our [CLA](https://gist.githubusercontent.com/emdgroup-admin/16cc45ea4315c2ef29eb9d9afc36fcf5/raw/abb9c91f15278a62b9ac3e66144bcd27fa9485c2/CLA.md)
- [x] Included tests (or is not applicable).
- [x] Updated [documentation](https://emdgroup.github.io/foundry-dev-tools/) (or is not applicable).
- [x] Used [pre-commit hooks](https://emdgroup.github.io/foundry-dev-tools/develop.html#pre-commit-hooks-formatting) to format and lint the code.
