### PR TITLE
Fix broken PySpark link by fixing typo

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -65,7 +65,7 @@ pip install 'foundry-dev-tools[transforms]'
 ```
 
 Alternative installation methods, or more information on how to get Spark running,
-can be found in the [PySpark Documenation] and the [Spark Documentation].
+can be found in the [PySpark Documentation] and the [Spark Documentation].
 
 [PySpark Documentation]: https://spark.apache.org/docs/latest/api/python/getting_started/install.html
 [Spark Documentation]: https://spark.apache.org/docs/latest/


### PR DESCRIPTION
# Summary

Fixed a typo in the documentation which resulted in a broken link

# Checklist

- [x] You agree with our [CLA](https://gist.githubusercontent.com/emdgroup-admin/16cc45ea4315c2ef29eb9d9afc36fcf5/raw/abb9c91f15278a62b9ac3e66144bcd27fa9485c2/CLA.md)
- [x] Included tests (or is not applicable).
- [x] Updated [documentation](https://emdgroup.github.io/foundry-dev-tools/) (or is not applicable).
- [x] Used [pre-commit hooks](https://emdgroup.github.io/foundry-dev-tools/develop.html#pre-commit-hooks-formatting) to format and lint the code.
