### PR TITLE
Improve Contribution guide by introducing "complete" profile & clarifying java version

### DIFF
--- a/docs/develop.md
+++ b/docs/develop.md
@@ -14,9 +14,19 @@ pip install -e .
 This command will link the local version of this package into your pip package folder.
 Every change you make in the code is instantly applied.
 
+## Setup Development Environment
+
+The easiest option is to open the repository with GitHub Codespaces, which offers a free tier as well.
+Spark in combination with pyarrow currently works only with Java<21 (`sun.misc.Unsafe or java.nio.DirectByteBuffer.<init>(long, int) not available`). 
+In Codespaces you can change the Java Version to 17 using:
+
+```shell
+sdk default java 17.0.9-ms
+```
+
 ## Run unit tests
 
-Install the test dependencies and execute pytest.
+Install all test dependencies and execute pytest.
 
 ```shell
 pip install -e ".[complete]"
@@ -33,8 +43,7 @@ tox
 
 To run the integration tests, make sure to have a valid `config` file in your `~/.foundry_dev_tools/` folder
 and have the environment variables `INTEGRATION_TEST_COMPASS_ROOT_PATH` and `INTEGRATION_TEST_COMPASS_ROOT_RID` set.
-These environment variables should point to an empty folder on palantir foundry you have permissions to,
-the tests will create the datasets automatically.
+These environment variables should point to an empty folder on your Palantir Foundry Stack you have permissions to, the tests will create the datasets automatically.
 
 ```shell
 pip install -e ".[integration,testing,transforms]"

--- a/docs/develop.md
+++ b/docs/develop.md
@@ -19,7 +19,7 @@ Every change you make in the code is instantly applied.
 Install the test dependencies and execute pytest.
 
 ```shell
-pip install -e ".[testing,transforms]"
+pip install -e ".[complete]"
 pytest
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ testing = [
 transforms = ["pyspark>=3.0.0"]
 cli = ["click", "inquirer", "websockets", "rich", "packaging"]
 s3 = ["aiobotocore[boto3]"]
+complete = ["foundry-dev-tools[integration,testing,transforms,cli,s3]"]
 
 [project.urls]
 Homepage = "https://emdgroup.github.io/foundry-dev-tools"

--- a/tox.ini
+++ b/tox.ini
@@ -14,11 +14,7 @@ passenv =
     HOME
     SETUPTOOLS_*
 extras =
-    testing
-    transforms
-    cli
-    integration
-    s3
+    complete
 commands =
     pytest {posargs}
 


### PR DESCRIPTION
# Summary
While trying to run the unit tests on a new computer/within Codespaces I realized that the contribution guide could be improved. With these changes it should be straight forward to follow to get Green Unit Tests on the first try.

# Checklist

- [X] You agree with our [CLA](https://gist.githubusercontent.com/emdgroup-admin/16cc45ea4315c2ef29eb9d9afc36fcf5/raw/abb9c91f15278a62b9ac3e66144bcd27fa9485c2/CLA.md)
- [ ] Included tests (or is not applicable).
- [X] Updated [documentation](https://emdgroup.github.io/foundry-dev-tools/) (or is not applicable).
- [X] Used [pre-commit hooks](https://emdgroup.github.io/foundry-dev-tools/develop.html#pre-commit-hooks-formatting) to format and lint the code.
