### PR TITLE
Release v1.4.0 and bump ruff version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
     args: ['--fix=lf']  # replace 'auto' with 'lf' to enforce Linux/Mac line endings or 'crlf' for Windows
 - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff version.
-  rev: 'v0.1.3'
+  rev: 'v0.1.15'
   hooks:
     - id: ruff
       args: ["--fix","--exit-non-zero-on-fix","--show-fixes"]

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog],
 and this project adheres to [Semantic Versioning].
 
+## [1.4.0] - 2024-02-05
+
+## Added
+
+- support for lightweight transforms (#47)
+
+## Fixed
+
+- PySpark link in installation docs (#48)
+
 ## [1.3.5] - 2023-12-05
 
 ## Fixed

--- a/src/foundry_dev_tools/config.py
+++ b/src/foundry_dev_tools/config.py
@@ -244,7 +244,7 @@ class Config(UserDict):
             raise KeyError(key)
         self.data[key] = None
 
-    def set(self, key, value):  # noqa: A003
+    def set(self, key, value):
         """Deprecated: Stores value in config.
 
         Args:

--- a/src/transforms/api/_transform.py
+++ b/src/transforms/api/_transform.py
@@ -538,7 +538,7 @@ class FileSystem:
                 result_path, "size not implemented", "modified not implemented"
             )
 
-    def open(self, path, mode="w", **kwargs):  # noqa: A003
+    def open(self, path, mode="w", **kwargs):
         """Open file in this filesystem.
 
         Args:


### PR DESCRIPTION
# Summary

- add changelog entry for v1.4.0
- bump ruff version to latest

# Checklist

- [x] You agree with our [CLA](https://gist.githubusercontent.com/emdgroup-admin/16cc45ea4315c2ef29eb9d9afc36fcf5/raw/abb9c91f15278a62b9ac3e66144bcd27fa9485c2/CLA.md)
- [x] Included tests (or is not applicable).
- [x] Updated [documentation](https://emdgroup.github.io/foundry-dev-tools/) (or is not applicable).
- [x] Used [pre-commit hooks](https://emdgroup.github.io/foundry-dev-tools/develop.html#pre-commit-hooks-formatting) to format and lint the code.
