### PR TITLE
Provide a function that allows querying branch names for datasets

### DIFF
--- a/src/foundry_dev_tools/foundry_api_client.py
+++ b/src/foundry_dev_tools/foundry_api_client.py
@@ -323,6 +323,24 @@ class FoundryRestClient:
         _raise_for_status_verbose(response)
         return response.json()
 
+    def get_branches(self, dataset_rid: str) -> list[str]:
+        """Returns a list of branches available a dataset.
+
+        Args:
+            dataset_rid (str): Unique identifier of the dataset
+
+        Returns:
+            list[str]:
+                with keys id (name) the dataset branches
+
+        """
+        response = self._request(
+            "GET",
+            f"{self.catalog}/catalog/datasets/{dataset_rid}/branches2",
+        )
+        _raise_for_status_verbose(response)
+        return response.json()
+
     def get_branch(self, dataset_rid: str, branch: str) -> dict:
         """Returns branch information.
 

--- a/tests/test_foundry_api.py
+++ b/tests/test_foundry_api.py
@@ -108,6 +108,9 @@ def test_monster_integration_test(client):  # noqa: PLR0915, TODO?
         _ = client.create_branch(ds["rid"], BRANCH)
     branch_returned = client.get_branch(ds["rid"], BRANCH)
     assert branch == branch_returned
+    branch_list = client.get_branches(ds["rid"])
+    assert len(branch_list) == 1
+    assert branch_list[0] == BRANCH
 
     assert client.get_dataset_identity(ds["rid"], BRANCH) == {
         "dataset_path": dataset_path,


### PR DESCRIPTION
# Summary

For many functions, the branch name needs to be provided but seems impossible to findout with the current API. This is resolved by this change.

# Checklist

- [X] You agree with our [CLA](https://gist.githubusercontent.com/emdgroup-admin/16cc45ea4315c2ef29eb9d9afc36fcf5/raw/abb9c91f15278a62b9ac3e66144bcd27fa9485c2/CLA.md)
- [X] Included tests (or is not applicable).
- [X] Updated [documentation](https://emdgroup.github.io/foundry-dev-tools/) (or is not applicable).
- [X] Used [pre-commit hooks](https://emdgroup.github.io/foundry-dev-tools/develop.html#pre-commit-hooks-formatting) to format and lint the code.
