### PR TITLE
Allow .git files for git_toplevel_dir identification to support git submodules

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog],
 and this project adheres to [Semantic Versioning].
 
+## [1.4.1] - 2024-05-29
+
+## Added
+  - Support for git submodules (#56)
+
 ## [1.4.0] - 2024-02-05
 
 ## Added
@@ -199,7 +204,9 @@ and this project adheres to [Semantic Versioning].
 [Keep a Changelog]: https://keepachangelog.com/en/1.0.0/
 [Semantic Versioning]: https://semver.org/spec/v2.0.0.html
 
-[1.3.4]: https://github.com/emdgroup/foundry-dev-tools/compare/v1.3.4...v1.3.5
+[1.4.1]: https://github.com/emdgroup/foundry-dev-tools/compare/v1.4.0...v1.4.1
+[1.4.0]: https://github.com/emdgroup/foundry-dev-tools/compare/v1.3.5...v1.4.0
+[1.3.5]: https://github.com/emdgroup/foundry-dev-tools/compare/v1.3.4...v1.3.5
 [1.3.4]: https://github.com/emdgroup/foundry-dev-tools/compare/v1.3.3...v1.3.4
 [1.3.3]: https://github.com/emdgroup/foundry-dev-tools/compare/v1.3.2...v1.3.3
 [1.3.2]: https://github.com/emdgroup/foundry-dev-tools/compare/v1.3.1...v1.3.2

--- a/src/foundry_dev_tools/utils/repo.py
+++ b/src/foundry_dev_tools/utils/repo.py
@@ -113,10 +113,10 @@ def git_toplevel_dir(
         )
     if git_dir is None:
         git_dir = Path.cwd()
-    if git_dir.joinpath(".git").is_dir():
+    if git_dir.joinpath(".git").exists():
         return git_dir
     for p in git_dir.resolve().parents:
-        if p.joinpath(".git").is_dir():
+        if p.joinpath(".git").exists():
             return p
     return None
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -206,3 +206,14 @@ def complex_dataset_fixture(client, spark_session, tmpdir):
             foundry_schema=FOUNDRY_SCHEMA_COMPLEX_DATASET,
         )
         yield ds_rid
+
+
+@pytest.fixture()
+def git_env():
+    return {
+        "GIT_CONFIG_NOSYSTEM": "1",
+        "GIT_COMMITTER_NAME": "Jon Doe",
+        "GIT_COMMITTER_EMAIL": "john@doe",
+        "GIT_AUTHOR_NAME": "Jon Doe",
+        "GIT_AUTHOR_EMAIL": "john@doe",
+    }

--- a/tests/test_cli_build.py
+++ b/tests/test_cli_build.py
@@ -454,15 +454,7 @@ def test_build(a, b, c, d, e, f, g, caplog):
         assert result.exit_code == 0
 
 
-def test_get_transform_files(tmpdir: "py.path.LocalPath"):
-    GIT_ENV = {
-        "HOME": str(tmpdir),
-        "GIT_CONFIG_NOSYSTEM": "1",
-        "GIT_COMMITTER_NAME": "pytest get_transform_files test",
-        "GIT_COMMITTER_EMAIL": "pytest@get_transform_files.py",
-        "GIT_AUTHOR_NAME": "pytest get_transform_files test",
-        "GIT_AUTHOR_EMAIL": "pytest@get_transform_files.py",
-    }  # should use default configs
+def test_get_transform_files(tmpdir: "py.path.LocalPath", git_env: dict):
     with tmpdir.as_cwd():
         from foundry_dev_tools.cli.build import (
             TRANSFORM_DECORATORS,
@@ -470,7 +462,7 @@ def test_get_transform_files(tmpdir: "py.path.LocalPath"):
             is_transform_file,
         )
 
-        subprocess.check_call(["git", "init"], env=GIT_ENV)
+        subprocess.check_call(["git", "init"], env=git_env)
         t = Path("transforms-python", "examples")
         t.mkdir(parents=True)
         tfiles = []
@@ -481,8 +473,8 @@ def test_get_transform_files(tmpdir: "py.path.LocalPath"):
                     f"from transforms.api import {decorator},Output\n\n@transform_df()\ndef test_transform():\n    pass"
                 )
             tfiles.append(transform_file.as_posix())  # git returns with forward slash
-        subprocess.check_call(["git", "add", "-A"], env=GIT_ENV)
-        subprocess.check_call(["git", "commit", "-m", "transform commit"], env=GIT_ENV)
+        subprocess.check_call(["git", "add", "-A"], env=git_env)
+        subprocess.check_call(["git", "commit", "-m", "transform commit"], env=git_env)
 
         for f in tfiles:
             assert is_transform_file(Path(f))
@@ -491,9 +483,9 @@ def test_get_transform_files(tmpdir: "py.path.LocalPath"):
         assert get_transform_files(Path.cwd()) == tfiles
         with tmpdir.join("get_transform.txt").open("w+") as gttxt:
             gttxt.write("something something")
-        subprocess.check_call(["git", "add", "-A"], env=GIT_ENV)
+        subprocess.check_call(["git", "add", "-A"], env=git_env)
         subprocess.check_call(
-            ["git", "commit", "-m", "no transform in last commit"], env=GIT_ENV
+            ["git", "commit", "-m", "no transform in last commit"], env=git_env
         )
         with pytest.raises(UsageError, match="No transform files in the last commit."):
             get_transform_files(Path.cwd())

--- a/tests/test_utils_repo.py
+++ b/tests/test_utils_repo.py
@@ -23,6 +23,24 @@ def test_git_toplevel_dir(use_git: bool, tmpdir: "py.path.LocalPath"):
         git_dir_cwd = git_toplevel_dir(use_git=use_git)
     assert git_dir_cwd == toplevel
 
+    # Test if git submodules can be recognized as toplevel_dir
+    # Use foundry-dev-tools as dummy submodule
+    subprocess.check_call(
+        [
+            "git",
+            "submodule",
+            "add",
+            "https://github.com/emdgroup/foundry-dev-tools.git",
+            "dummy_submodule",
+        ],
+        cwd=toplevel,
+    )
+    toplevel_submodule = toplevel.joinpath("dummy_submodule")
+    git_dir_submodule = git_toplevel_dir(
+        Path(tmpdir.mkdir("dummy_submodule", "submodule_subdirectory")), use_git=use_git
+    )
+    assert git_dir_submodule == toplevel_submodule
+
 
 def test_get_repo(tmpdir: "py.path.LocalPath"):
     repo_rid = f"ri.stemma.main.repository{uuid.uuid4()}"

--- a/tests/test_utils_repo.py
+++ b/tests/test_utils_repo.py
@@ -25,18 +25,23 @@ def test_git_toplevel_dir(use_git: bool, tmpdir: "py.path.LocalPath"):
 
     # Test if git submodules can be recognized as toplevel_dir
     # First create an empty local repository and initialize it
-    subprocess.check_call(["git", "init", "dummy_repo"], cwd=toplevel)
-
+    git_env = {
+        "GIT_COMMITTER_NAME": "pytest get_transform_files test",
+        "GIT_COMMITTER_EMAIL": "pytest@get_transform_files.py",
+        "GIT_AUTHOR_NAME": "pytest get_repo test",
+        "GIT_AUTHOR_EMAIL": "pytest@get_repo.py",
+    }
+    subprocess.check_call(["git", "init", "dummy_repo"], cwd=toplevel, env=git_env)
     subprocess.check_call(
         [
             "git",
             "commit",
-            "--author='John Doe <john@doe.com>'",
             "--allow-empty",
             "-m",
             "Initialize",
         ],
         cwd=toplevel.joinpath("dummy_repo"),
+        env=git_env,
     )
 
     # Add local repository as submodule to toplevel repo

--- a/tests/test_utils_repo.py
+++ b/tests/test_utils_repo.py
@@ -24,13 +24,22 @@ def test_git_toplevel_dir(use_git: bool, tmpdir: "py.path.LocalPath"):
     assert git_dir_cwd == toplevel
 
     # Test if git submodules can be recognized as toplevel_dir
-    # Use foundry-dev-tools as dummy submodule
+    # First create an empty local repository and initialize it
+    subprocess.check_call(["git", "init", "dummy_repo"], cwd=toplevel)
+    subprocess.check_call(
+        ["git", "commit", "--allow-empty", "-m", "Initialize"],
+        cwd=toplevel.joinpath("dummy_repo"),
+    )
+
+    # Add local repository as submodule to toplevel repo
     subprocess.check_call(
         [
             "git",
+            "-c",
+            "protocol.file.allow=always",
             "submodule",
             "add",
-            "https://github.com/emdgroup/foundry-dev-tools.git",
+            "./dummy_repo",
             "dummy_submodule",
         ],
         cwd=toplevel,

--- a/tests/test_utils_repo.py
+++ b/tests/test_utils_repo.py
@@ -26,8 +26,16 @@ def test_git_toplevel_dir(use_git: bool, tmpdir: "py.path.LocalPath"):
     # Test if git submodules can be recognized as toplevel_dir
     # First create an empty local repository and initialize it
     subprocess.check_call(["git", "init", "dummy_repo"], cwd=toplevel)
+
     subprocess.check_call(
-        ["git", "commit", "--allow-empty", "-m", "Initialize"],
+        [
+            "git",
+            "commit",
+            "--author='John Doe <john@doe.com>'",
+            "--allow-empty",
+            "-m",
+            "Initialize",
+        ],
         cwd=toplevel.joinpath("dummy_repo"),
     )
 

--- a/tests/test_utils_repo.py
+++ b/tests/test_utils_repo.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 @pytest.mark.parametrize(
     "use_git", [False]
 )  # only False, as we test use_git=True with test_get_repo
-def test_git_toplevel_dir(use_git: bool, tmpdir: "py.path.LocalPath"):
+def test_git_toplevel_dir(use_git: bool, tmpdir: "py.path.LocalPath", git_env: dict):
     toplevel = Path(tmpdir)
     subprocess.check_call(["git", "init"], cwd=toplevel)
     git_dir = git_toplevel_dir(Path(tmpdir.mkdir("subdireectory")), use_git=use_git)
@@ -25,12 +25,6 @@ def test_git_toplevel_dir(use_git: bool, tmpdir: "py.path.LocalPath"):
 
     # Test if git submodules can be recognized as toplevel_dir
     # First create an empty local repository and initialize it
-    git_env = {
-        "GIT_COMMITTER_NAME": "pytest get_transform_files test",
-        "GIT_COMMITTER_EMAIL": "pytest@get_transform_files.py",
-        "GIT_AUTHOR_NAME": "pytest get_repo test",
-        "GIT_AUTHOR_EMAIL": "pytest@get_repo.py",
-    }
     subprocess.check_call(["git", "init", "dummy_repo"], cwd=toplevel, env=git_env)
     subprocess.check_call(
         [
@@ -64,23 +58,16 @@ def test_git_toplevel_dir(use_git: bool, tmpdir: "py.path.LocalPath"):
     assert git_dir_submodule == toplevel_submodule
 
 
-def test_get_repo(tmpdir: "py.path.LocalPath"):
+def test_get_repo(tmpdir: "py.path.LocalPath", git_env: dict):
     repo_rid = f"ri.stemma.main.repository{uuid.uuid4()}"
     git_dir = Path(tmpdir)
     subprocess.check_call(["git", "init"], cwd=git_dir)
     with git_dir.joinpath("gradle.properties").open("w+") as gradle_prop:
         gradle_prop.write(f"transformsRepoRid = {repo_rid}")
-    GIT_ENV = {
-        "HOME": str(git_dir),
-        "GIT_CONFIG_NOSYSTEM": "1",
-        "GIT_COMMITTER_NAME": "pytest get_repo test",
-        "GIT_COMMITTER_EMAIL": "pytest@get_repo.py",
-        "GIT_AUTHOR_NAME": "pytest get_repo test",
-        "GIT_AUTHOR_EMAIL": "pytest@get_repo.py",
-    }  # should use default configs
-    subprocess.check_call(["git", "add", "gradle.properties"], cwd=git_dir, env=GIT_ENV)
+
+    subprocess.check_call(["git", "add", "gradle.properties"], cwd=git_dir, env=git_env)
     subprocess.check_call(
-        ["git", "commit", "-m", "initial commit"], cwd=git_dir, env=GIT_ENV
+        ["git", "commit", "-m", "initial commit"], cwd=git_dir, env=git_env
     )
     assert get_repo(git_dir)[0] == repo_rid
     with tmpdir.as_cwd():


### PR DESCRIPTION
# Summary

For projects with multiple (Foundry code) repositories, it can be handy to add them as [git submodules](https://git-scm.com/book/en/v2/Git-Tools-Submodules) to a leading project repository.  In that case, the existing implementation would fail at e.g. the branch identification for transforms in submodules, as the ```git_toplevel_dir``` is assumed to contain a **.git directory**, while submodules only add a **.git file**. 

The proposed solution is to change from ```...(".git").is_dir()``` to ```...(".git").exists()```, allowing files and directories. The respective test case has been extended to cover both scenarios.


# Checklist

- [x] You agree with our [CLA](https://gist.githubusercontent.com/emdgroup-admin/16cc45ea4315c2ef29eb9d9afc36fcf5/raw/abb9c91f15278a62b9ac3e66144bcd27fa9485c2/CLA.md)
- [x] Included tests (or is not applicable).
- [x] Updated [documentation](https://emdgroup.github.io/foundry-dev-tools/) (or is not applicable).
- [x] Used [pre-commit hooks](https://emdgroup.github.io/foundry-dev-tools/develop.html#pre-commit-hooks-formatting) to format and lint the code.
