### PR TITLE
Add transform input branch inference for git submodules

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog],
 and this project adheres to [Semantic Versioning].
 
+## [1.4.2] - 2024-06-03
+
+## Added
+  - Support for git submodules in transforms (#57)
+
 ## [1.4.1] - 2024-05-29
 
 ## Added
@@ -204,6 +209,7 @@ and this project adheres to [Semantic Versioning].
 [Keep a Changelog]: https://keepachangelog.com/en/1.0.0/
 [Semantic Versioning]: https://semver.org/spec/v2.0.0.html
 
+[1.4.2]: https://github.com/emdgroup/foundry-dev-tools/compare/v1.4.1...v1.4.2
 [1.4.1]: https://github.com/emdgroup/foundry-dev-tools/compare/v1.4.0...v1.4.1
 [1.4.0]: https://github.com/emdgroup/foundry-dev-tools/compare/v1.3.5...v1.4.0
 [1.3.5]: https://github.com/emdgroup/foundry-dev-tools/compare/v1.3.4...v1.3.5

--- a/src/foundry_dev_tools/utils/repo.py
+++ b/src/foundry_dev_tools/utils/repo.py
@@ -121,6 +121,42 @@ def git_toplevel_dir(
     return None
 
 
+def get_branch(caller_filename: Path) -> str:
+    """Get name of current checked out git branch as defined in the git HEAD file.
+
+    Args:
+        caller_filename (Path): Path of file that calls the function
+
+    Returns:
+        str: Name of checked out branch
+    """
+    git_dir = git_toplevel_dir(caller_filename)
+    if not git_dir:
+        # fallback for VS Interactive Console
+        # or Jupyter lab on Windows
+        git_dir = Path.cwd()
+
+    if git_dir.joinpath(".git").is_file():
+        # Infer branch from git submodule
+        with git_dir.joinpath(".git").open() as gf:
+            rel_submodule_git_dir = gf.read().strip().replace("gitdir: ", "")
+        head_file = git_dir.joinpath(rel_submodule_git_dir, "HEAD").resolve()
+    else:
+        head_file = git_dir.joinpath(".git", "HEAD")
+
+    if head_file.is_file():
+        with head_file.open() as hf:
+            ref = hf.read().strip()
+
+        if ref.startswith("ref: refs/heads/"):
+            return ref[16:]
+
+        return "HEAD"  # immitate behaviour of `git rev-parse --abbrev-ref HEAD`
+
+    warnings.warn("Could not detect git branch of project, falling back to 'master'.")
+    return "master"
+
+
 def find_project_config_file(
     project_directory: "Path | None" = None, use_git: bool = False
 ) -> "Path | None":

--- a/src/transforms/api/_dataset.py
+++ b/src/transforms/api/_dataset.py
@@ -287,7 +287,7 @@ def _get_branch(caller_filename: Path) -> str:
         git_dir = Path.cwd()
 
     if git_dir.joinpath(".git").is_file():
-        # Infer branch from git submoduel
+        # Infer branch from git submodule
         with git_dir.joinpath(".git").open() as gf:
             rel_submodule_git_dir = gf.read().strip().replace("gitdir: ", "")
         head_file = git_dir.joinpath(rel_submodule_git_dir, "HEAD").resolve()

--- a/src/transforms/api/_dataset.py
+++ b/src/transforms/api/_dataset.py
@@ -286,7 +286,14 @@ def _get_branch(caller_filename: Path) -> str:
         # or Jupyter lab on Windows
         git_dir = Path.cwd()
 
-    head_file = git_dir.joinpath(".git", "HEAD")
+    if git_dir.joinpath(".git").is_file():
+        # Infer branch from git submoduel
+        with git_dir.joinpath(".git").open() as gf:
+            rel_submodule_git_dir = gf.read().strip().replace("gitdir: ", "")
+        head_file = git_dir.joinpath(rel_submodule_git_dir, "HEAD").resolve()
+    else:
+        head_file = git_dir.joinpath(".git", "HEAD")
+
     if head_file.is_file():
         with head_file.open() as hf:
             ref = hf.read().strip()

--- a/src/transforms/api/_dataset.py
+++ b/src/transforms/api/_dataset.py
@@ -23,7 +23,7 @@ from foundry_dev_tools.foundry_api_client import (
 )
 from foundry_dev_tools.utils.caches.spark_caches import DiskPersistenceBackedSparkCache
 from foundry_dev_tools.utils.misc import is_dataset_a_view
-from foundry_dev_tools.utils.repo import git_toplevel_dir
+from foundry_dev_tools.utils.repo import get_branch
 
 LOGGER = logging.getLogger(__name__)
 
@@ -87,7 +87,7 @@ class Input:
         self._cache = DiskPersistenceBackedSparkCache(**self.config)
         self._spark_df = None
         if branch is None:
-            branch = _get_branch(Path(caller_filename))
+            branch = get_branch(Path(caller_filename))
 
         if self._is_online:
             (
@@ -277,34 +277,6 @@ class Input:
             if self._is_online
             else self._cache.get_path_to_local_dataset(self._dataset_identity)
         )
-
-
-def _get_branch(caller_filename: Path) -> str:
-    git_dir = git_toplevel_dir(caller_filename)
-    if not git_dir:
-        # fallback for VS Interactive Console
-        # or Jupyter lab on Windows
-        git_dir = Path.cwd()
-
-    if git_dir.joinpath(".git").is_file():
-        # Infer branch from git submodule
-        with git_dir.joinpath(".git").open() as gf:
-            rel_submodule_git_dir = gf.read().strip().replace("gitdir: ", "")
-        head_file = git_dir.joinpath(rel_submodule_git_dir, "HEAD").resolve()
-    else:
-        head_file = git_dir.joinpath(".git", "HEAD")
-
-    if head_file.is_file():
-        with head_file.open() as hf:
-            ref = hf.read().strip()
-
-        if ref.startswith("ref: refs/heads/"):
-            return ref[16:]
-
-        return "HEAD"  # immitate behaviour of `git rev-parse --abbrev-ref HEAD`
-
-    warnings.warn("Could not detect git branch of project, falling back to 'master'.")
-    return "master"
 
 
 class Output:

--- a/tests/test_utils_repo.py
+++ b/tests/test_utils_repo.py
@@ -1,3 +1,4 @@
+import os
 import subprocess
 import uuid
 from pathlib import Path
@@ -5,7 +6,8 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from foundry_dev_tools.utils.repo import get_repo, git_toplevel_dir
+from foundry_dev_tools.utils.repo import get_branch, get_repo, git_toplevel_dir
+from tests.utils import add_git_submodule
 
 if TYPE_CHECKING:
     import py.path
@@ -24,44 +26,65 @@ def test_git_toplevel_dir(use_git: bool, tmpdir: "py.path.LocalPath", git_env: d
     assert git_dir_cwd == toplevel
 
     # Test if git submodules can be recognized as toplevel_dir
-    # First create an empty local repository and initialize it
-    subprocess.check_call(["git", "init", "dummy_repo"], cwd=toplevel, env=git_env)
-    subprocess.check_call(
-        [
-            "git",
-            "commit",
-            "--allow-empty",
-            "-m",
-            "Initialize",
-        ],
-        cwd=toplevel.joinpath("dummy_repo"),
-        env=git_env,
-    )
-
-    # Add local repository as submodule to toplevel repo
-    subprocess.check_call(
-        [
-            "git",
-            "-c",
-            "protocol.file.allow=always",
-            "submodule",
-            "add",
-            "./dummy_repo",
-            "dummy_submodule",
-        ],
-        cwd=toplevel,
-    )
-    toplevel_submodule = toplevel.joinpath("dummy_submodule")
+    submodule_name = "dummy_submodule"
+    add_git_submodule(git_dir=toplevel, submodule_name=submodule_name, git_env=git_env)
+    toplevel_submodule = toplevel.joinpath(submodule_name)
     git_dir_submodule = git_toplevel_dir(
-        Path(tmpdir.mkdir("dummy_submodule", "submodule_subdirectory")), use_git=use_git
+        Path(tmpdir.mkdir(submodule_name, "submodule_subdirectory")), use_git=use_git
     )
     assert git_dir_submodule == toplevel_submodule
+
+
+def test_get_branch(tmpdir: "py.path.LocalPath", git_env: dict):
+    toplevel = Path(tmpdir)
+
+    # Test without git submodule
+    parent_repo_name = "parent_repo"
+    target_branch_name_parent = "parent_repo_main"
+    subprocess.check_call(
+        [
+            "git",
+            "init",
+            parent_repo_name,
+            f"--initial-branch={target_branch_name_parent}",
+        ],
+        cwd=toplevel,
+        env=git_env,
+    )
+    branch_name = get_branch(toplevel.joinpath(parent_repo_name))
+    assert branch_name == target_branch_name_parent
+
+    # Test for git submodule
+    # Add an empty submodule
+    submodule_name = "dummy_submodule"
+    add_git_submodule(
+        git_dir=toplevel.joinpath(parent_repo_name),
+        submodule_name=submodule_name,
+        git_env=git_env,
+    )
+    # Checkout and test new branch from submodule
+    target_branch_name_sub = "submodule_repo_dev"
+    git_dir_submodule = toplevel.joinpath(parent_repo_name, submodule_name)
+    subprocess.check_call(
+        [
+            "git",
+            "checkout",
+            "-b",
+            target_branch_name_sub,
+        ],
+        cwd=git_dir_submodule,
+        env=git_env,
+    )
+    assert os.path.isfile(git_dir_submodule.joinpath(".git"))
+
+    branch_name = get_branch(git_dir_submodule)
+    assert branch_name == target_branch_name_sub
 
 
 def test_get_repo(tmpdir: "py.path.LocalPath", git_env: dict):
     repo_rid = f"ri.stemma.main.repository{uuid.uuid4()}"
     git_dir = Path(tmpdir)
-    subprocess.check_call(["git", "init"], cwd=git_dir)
+    subprocess.check_call(["git", "init"], cwd=git_dir, env=git_env)
     with git_dir.joinpath("gradle.properties").open("w+") as gradle_prop:
         gradle_prop.write(f"transformsRepoRid = {repo_rid}")
 


### PR DESCRIPTION
# Summary

After allowing .git files for submodules in [PR56](https://github.com/emdgroup/foundry-dev-tools/pull/56), this PR adds branch inference for transform inputs in git submodules. 

# Checklist

- [x] You agree with our [CLA](https://gist.githubusercontent.com/emdgroup-admin/16cc45ea4315c2ef29eb9d9afc36fcf5/raw/abb9c91f15278a62b9ac3e66144bcd27fa9485c2/CLA.md)
- [x] Included tests (or is not applicable).
- [x] Updated [documentation](https://emdgroup.github.io/foundry-dev-tools/) (or is not applicable).
- [x] Used [pre-commit hooks](https://emdgroup.github.io/foundry-dev-tools/develop.html#pre-commit-hooks-formatting) to format and lint the code.
