### PR TITLE
feat: add official streamlit context headers method

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog],
 and this project adheres to [Semantic Versioning].
 
+## [1.5.0] - 2024-07-31
+
+## Added
+  - Official Streamlit Headers method since Streamlit Version 1.37.0 (#58)
+
 ## [1.4.3] - 2024-07-11
 
 ## Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,6 @@ fdt = "foundry_dev_tools.cli.main:cli"
 foundry = "foundry_dev_tools.fsspec_impl.FoundryFileSystem"
 
 [project.optional-dependencies]
-integration = ["dask", "fastparquet"]
 testing = [
   "pytest",
   "pytest-mock",
@@ -54,8 +53,10 @@ testing = [
   "requests-mock",
   "fsspec",
   "timeflake",
-  "polars"
+  "polars",
+  "streamlit",
 ]
+integration = ["dask", "fastparquet"]
 transforms = ["pyspark>=3.0.0"]
 cli = ["click", "inquirer", "websockets", "rich", "packaging"]
 s3 = ["aiobotocore[boto3]"]

--- a/src/foundry_dev_tools/utils/token_provider.py
+++ b/src/foundry_dev_tools/utils/token_provider.py
@@ -1,4 +1,5 @@
 """Token Provider for common UPTIMIZE AppService."""
+
 from abc import abstractmethod
 
 from requests.structures import CaseInsensitiveDict
@@ -76,6 +77,11 @@ class AppServiceStreamlitTokenProvider(AbstractTokenProvider):
                 request headers
 
         """
+        import streamlit as st
+
+        if hasattr(st, "context"):
+            return st.context.headers
+
         from streamlit.scriptrunner.script_run_context import get_script_run_ctx
         from streamlit.server.server import Server
 

--- a/tests/test_token_provider.py
+++ b/tests/test_token_provider.py
@@ -1,18 +1,21 @@
 """Tests for the tokenproviders."""
+
 import sys
+from argparse import Namespace
 from unittest import mock
 
 import pytest
+from pytest_mock import MockerFixture
 
 from foundry_dev_tools.utils.token_provider import APP_SERVICE_ACCESS_TOKEN_HEADER
 from tests.conftest import PatchConfig
 
 
-def test_token_provider_streamlit(mocker):
+def test_token_provider_streamlit(mocker: MockerFixture):
     """Tests the streamlit token provider."""
     mocker.patch(
-        "foundry_dev_tools.utils.token_provider.AppServiceStreamlitTokenProvider.get_streamlit_request_headers",
-        return_value={APP_SERVICE_ACCESS_TOKEN_HEADER: "secret-token"},
+        "streamlit.context",
+        Namespace(headers={APP_SERVICE_ACCESS_TOKEN_HEADER: "secret-token"}),
     )
     with PatchConfig(config_overwrite={"jwt": None}):
         from foundry_dev_tools.foundry_api_client import FoundryRestClient
@@ -20,6 +23,16 @@ def test_token_provider_streamlit(mocker):
         client = FoundryRestClient()
         print(client._config)
         assert client._config["jwt"] == "secret-token"
+    mocker.patch(
+        "foundry_dev_tools.utils.token_provider.AppServiceStreamlitTokenProvider.get_streamlit_request_headers",
+        return_value={APP_SERVICE_ACCESS_TOKEN_HEADER: "secret-token2"},
+    )
+    with PatchConfig(config_overwrite={"jwt": None}):
+        from foundry_dev_tools.foundry_api_client import FoundryRestClient
+
+        client = FoundryRestClient()
+        print(client._config)
+        assert client._config["jwt"] == "secret-token2"
 
 
 def test_token_provider_streamlit_114_case_insensitive():


### PR DESCRIPTION
# Summary

Added the `st.context.headers` official Streamlit variant to get request headers

# Checklist

- [x] You agree with our [CLA](https://gist.githubusercontent.com/emdgroup-admin/16cc45ea4315c2ef29eb9d9afc36fcf5/raw/abb9c91f15278a62b9ac3e66144bcd27fa9485c2/CLA.md)
- [x] Included tests (or is not applicable).
- [x] Updated [documentation](https://emdgroup.github.io/foundry-dev-tools/) (or is not applicable).
- [x] Used [pre-commit hooks](https://emdgroup.github.io/foundry-dev-tools/develop.html#pre-commit-hooks-formatting) to format and lint the code.
