### PR TITLE
fix: don't show warnings for empty token provider configurations

### DIFF
--- a/libs/foundry-dev-tools/src/foundry_dev_tools/config/config.py
+++ b/libs/foundry-dev-tools/src/foundry_dev_tools/config/config.py
@@ -227,7 +227,9 @@ def parse_credentials_config(config_dict: dict | None) -> TokenProvider:
         try:
             tp_name, tp_config = credentials_config.popitem()
             # make it possible to do jwt = "eyJ" instead of jwt = {jwt="eyJ"}
-            if not isinstance(tp_config, dict):
+            if tp_config is None or len(tp_config) == 0:
+                tp_config = {}
+            elif not isinstance(tp_config, dict):
                 tp_config = {tp_name: tp_config}
         except KeyError:
             tp_name, tp_config = None, None

--- a/tests/unit/config/test_context.py
+++ b/tests/unit/config/test_context.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import warnings
 from typing import TYPE_CHECKING
 from unittest import mock
 
@@ -15,11 +16,13 @@ if TYPE_CHECKING:
 
 
 def test_app_service(mock_config_location: dict[Path, None]):
-    with (
+    with (  # noqa: PT012
         mock.patch.dict(os.environ, {"APP_SERVICE_TS": "1", "FDT_CREDENTIALS__DOMAIN": TEST_DOMAIN}, clear=True),
         pytest.raises(
             FoundryConfigError,
             match="Could not get Foundry token from flask/dash/streamlit headers.",
         ),
+        warnings.catch_warnings(),
     ):
+        warnings.simplefilter("error")  # raise errors on warnings
         _ = FoundryContext()


### PR DESCRIPTION
# Summary

<!-- summary of your changes -->

# Checklist

- [x] You agree with our [CLA](https://gist.githubusercontent.com/emdgroup-admin/16cc45ea4315c2ef29eb9d9afc36fcf5/raw/abb9c91f15278a62b9ac3e66144bcd27fa9485c2/CLA.md)
- [x] Included tests (or is not applicable).
- [x] Updated [documentation](https://emdgroup.github.io/foundry-dev-tools/) (or is not applicable).
- [x] Used [pre-commit hooks](https://emdgroup.github.io/foundry-dev-tools/develop.html#pre-commit-hooks-formatting) to format and lint the code.
