### PR TITLE
fix: Properly pass scopes to Multipass Endpoint in CC Flow.

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog],
 and this project adheres to [Semantic Versioning].
 
+## [2.1.5] - 2024-08-30
+## Fixed
+  - properly pass scopes to multipass endpoint in client_credentials flow
+
 ## [2.1.4] - 2024-08-30
 ## Added
   - check current working directory too in find_project_config_file
@@ -267,6 +271,7 @@ and this project adheres to [Semantic Versioning].
 [Keep a Changelog]: https://keepachangelog.com/en/1.0.0/
 [Semantic Versioning]: https://semver.org/spec/v2.0.0.html
 
+[2.1.5]: https://github.com/emdgroup/foundry-dev-tools/compare/v2.1.4...v2.1.5
 [2.1.4]: https://github.com/emdgroup/foundry-dev-tools/compare/v2.1.3...v2.1.4
 [2.1.3]: https://github.com/emdgroup/foundry-dev-tools/compare/v2.1.2...v2.1.3
 [2.1.2]: https://github.com/emdgroup/foundry-dev-tools/compare/v2.1.1...v2.1.2

--- a/libs/foundry-dev-tools/src/foundry_dev_tools/config/token_provider.py
+++ b/libs/foundry-dev-tools/src/foundry_dev_tools/config/token_provider.py
@@ -171,7 +171,7 @@ class OAuthTokenProvider(CachedTokenProvider):
             resp = requests.request(
                 "POST",
                 f"{self.host.url}/multipass/api/oauth2/token",
-                data={"grant_type": "client_credentials", "scope": self.scopes}
+                data={"grant_type": "client_credentials", "scope": " ".join(self.scopes)}
                 if self.scopes
                 else {"grant_type": "client_credentials"},
                 headers={

--- a/tests/unit/config/test_token_provider.py
+++ b/tests/unit/config/test_token_provider.py
@@ -94,6 +94,17 @@ def test_oauth_token_provider(mocker: MockerFixture):
     request_mock.assert_called_once()
     assert cc_tok == "token"
 
+    request_mock.reset_mock()
+
+    tp_cc_multiple_scopes = MockOAuthTokenProvider(
+        "client_id", "client_secret", grant_type="client_credentials", scopes=["scope1", "scope2"]
+    )
+    assert tp_cc_multiple_scopes.scopes == ["scope1", "scope2"]
+
+    tp_cc_multiple_scopes_tok = tp_cc_multiple_scopes.token
+    assert request_mock.call_args_list[0][1]["data"]["scope"] == "scope1 scope2"
+    assert tp_cc_multiple_scopes_tok == "token"
+
 
 def test_foundry_client_credentials_provider(foundry_token, foundry_client_id, foundry_client_secret):
     ctx = FoundryMockContext(


### PR DESCRIPTION
# Summary

- Fix a bug where multiple scopes were not passed properly to multipass.

# Checklist

- [X] You agree with our [CLA](https://gist.githubusercontent.com/emdgroup-admin/16cc45ea4315c2ef29eb9d9afc36fcf5/raw/abb9c91f15278a62b9ac3e66144bcd27fa9485c2/CLA.md)
- [X] Included tests (or is not applicable).
- [ ] Updated [documentation](https://emdgroup.github.io/foundry-dev-tools/) (or is not applicable).
- [X] Used [pre-commit hooks](https://emdgroup.github.io/foundry-dev-tools/develop.html#pre-commit-hooks-formatting) to format and lint the code.
