### PR TITLE
fix: quote repo name in clone url & other fixes

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog],
 and this project adheres to [Semantic Versioning].
 
+## [2.1.6] - 2024-09-13
+## Added:
+  - Retry request 3 times on ConnectionError
+## Fixed
+  - quote repository name in git clone url
+  - fix printing of Datasets instantiated by ctx.get_resource(rid)
+
 ## [2.1.5] - 2024-08-30
 ## Fixed
   - properly pass scopes to multipass endpoint in client_credentials flow

--- a/libs/foundry-dev-tools/src/foundry_dev_tools/cli/git.py
+++ b/libs/foundry-dev-tools/src/foundry_dev_tools/cli/git.py
@@ -3,7 +3,7 @@
 import os
 import re
 import subprocess
-from urllib.parse import urlparse
+from urllib.parse import quote, urlparse
 
 import click
 from rich.console import Console
@@ -65,9 +65,9 @@ def _git_clone_cli(ctx: FoundryContext, console: Console, repo: str, path: str |
     if repo_id is None:
         return
     repo_object = ctx.get_resource(repo_id)
-    clone_url = f"{ctx.host.scheme}://{ctx.host.domain}/stemma/git/{repo_id}/{repo_object.name}"
+    clone_url = f"{ctx.host.scheme}://{ctx.host.domain}" + quote(f"/stemma/git/{repo_id}/{repo_object.name}")
 
-    _path = "" if path is None else path
+    _path = repo_object.name if path is None else path
     console.print(f"Executing git clone {clone_url} {path}")
     if _path:
         os.execvp("git", ["git", "clone", clone_url, _path])  # noqa: S606

--- a/libs/foundry-dev-tools/src/foundry_dev_tools/resources/dataset.py
+++ b/libs/foundry-dev-tools/src/foundry_dev_tools/resources/dataset.py
@@ -797,7 +797,9 @@ class Dataset(resource.Resource):
 
     def _get_repr_dict(self) -> dict:
         d = super()._get_repr_dict()
-        d["branch"] = d["branch"]["id"]
+        if not hasattr(self, "branch"):
+            self.branch = self._context.catalog.api_get_branch(self.rid, "master").json()
+        d["branch"] = self.branch["id"]
         return d
 
 

--- a/tests/unit/cli/test_git.py
+++ b/tests/unit/cli/test_git.py
@@ -1,6 +1,7 @@
 from functools import partial
 from subprocess import CalledProcessError
 from unittest.mock import MagicMock, _Call, patch
+from urllib.parse import quote
 
 from pytest_mock.plugin import MockerFixture
 from rich.console import Console
@@ -74,7 +75,7 @@ def test_parse_repo(test_context_mock, mocker: MockerFixture):
 @patch("foundry_dev_tools.cli.git.subprocess.check_output")
 @patch("foundry_dev_tools.cli.git.os.execvp")
 def test_git_clone_cli(mock_execvp: MagicMock, mock_check_output: MagicMock, mocker, test_context_mock):
-    repo_name = "test-repo"
+    repo_name = "test repo"
     test_context_mock.mock_adapter.register_uri(
         "GET",
         build_api_url(test_context_mock.host.url, "compass", f"resources/{REPO_RID}"),
@@ -164,7 +165,7 @@ def test_git_clone_cli(mock_execvp: MagicMock, mock_check_output: MagicMock, moc
                     [
                         "git",
                         "clone",
-                        f"{test_context_mock.host.url}/stemma/git/{REPO_RID}/{repo_name}",
+                        f"{test_context_mock.host.url}/stemma/git/{REPO_RID}/{quote(repo_name)}",
                         ".",
                     ],
                 ),
@@ -185,7 +186,8 @@ def test_git_clone_cli(mock_execvp: MagicMock, mock_check_output: MagicMock, moc
                     [
                         "git",
                         "clone",
-                        f"{test_context_mock.host.url}/stemma/git/{REPO_RID}/{repo_name}",
+                        f"{test_context_mock.host.url}/stemma/git/{REPO_RID}/{quote(repo_name)}",
+                        repo_name,
                     ],
                 ),
                 {},

--- a/tests/unit/clients/test_context_client.py
+++ b/tests/unit/clients/test_context_client.py
@@ -1,6 +1,7 @@
 import time
 from unittest import mock
 
+import requests
 from requests_mock import ANY
 
 from foundry_dev_tools.__about__ import __version__
@@ -40,3 +41,11 @@ def test_context_http_client(test_context_mock, foundry_client_id):
     for token in tokens:
         req = test_context_mock.client.request("GET", "http+mock://test_oauth_token").request
         assert req.headers["Authorization"] == f"Bearer {token}"
+
+
+def test_retry_on_connection_error(test_context_mock):
+    response_mock = mock.Mock()
+    with mock.patch("requests.Session.request") as m:
+        m.side_effect = [requests.exceptions.ConnectionError(), response_mock]
+        response = test_context_mock.client.request("GET", "test_call_args")
+        assert response is response_mock


### PR DESCRIPTION
# Summary

The clone command failed if a repository name contained a space

# Checklist

- [x] You agree with our [CLA](https://gist.githubusercontent.com/emdgroup-admin/16cc45ea4315c2ef29eb9d9afc36fcf5/raw/abb9c91f15278a62b9ac3e66144bcd27fa9485c2/CLA.md)
- [x] Included tests (or is not applicable).
- [x] Updated [documentation](https://emdgroup.github.io/foundry-dev-tools/) (or is not applicable).
- [x] Used [pre-commit hooks](https://emdgroup.github.io/foundry-dev-tools/develop.html#pre-commit-hooks-formatting) to format and lint the code.
