### PR TITLE
fix(dataset): lazily fetch dataset branch if it was not fetched on init

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,7 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog],
 and this project adheres to [Semantic Versioning].
 
+## [2.1.7] - 2024-09-16
+
+## Fixed
+  - fix uninitialized branch attribute for Dataset class (#73)
+
 ## [2.1.6] - 2024-09-13
+
 ## Added:
   - Retry request 3 times on ConnectionError
 ## Fixed
@@ -13,10 +19,12 @@ and this project adheres to [Semantic Versioning].
   - fix printing of Datasets instantiated by ctx.get_resource(rid)
 
 ## [2.1.5] - 2024-08-30
+
 ## Fixed
   - properly pass scopes to multipass endpoint in client_credentials flow
 
 ## [2.1.4] - 2024-08-30
+
 ## Added
   - check current working directory too in find_project_config_file
 
@@ -278,6 +286,8 @@ and this project adheres to [Semantic Versioning].
 [Keep a Changelog]: https://keepachangelog.com/en/1.0.0/
 [Semantic Versioning]: https://semver.org/spec/v2.0.0.html
 
+[2.1.7]: https://github.com/emdgroup/foundry-dev-tools/compare/v2.1.6...v2.1.7
+[2.1.6]: https://github.com/emdgroup/foundry-dev-tools/compare/v2.1.5...v2.1.6
 [2.1.5]: https://github.com/emdgroup/foundry-dev-tools/compare/v2.1.4...v2.1.5
 [2.1.4]: https://github.com/emdgroup/foundry-dev-tools/compare/v2.1.3...v2.1.4
 [2.1.3]: https://github.com/emdgroup/foundry-dev-tools/compare/v2.1.2...v2.1.3

--- a/tests/integration/resources/test_dataset.py
+++ b/tests/integration/resources/test_dataset.py
@@ -29,6 +29,13 @@ def test_crud_dataset(spark_session, tmp_path):  # noqa: PLR0915
     ds2 = Dataset.from_rid(TEST_SINGLETON.ctx, ds.rid)
     assert ds2.path == ds.path
 
+    # test getting the dataset via .get_resource
+    ds3 = TEST_SINGLETON.ctx.get_resource(ds.rid)
+    assert ds3.path == ds.path
+    assert ds3.branch == ds.branch
+    # test for the branch attribute missing bug
+    ds3.__repr__()
+
     assert ds.get_last_transaction() is None
 
     ds.start_transaction()


### PR DESCRIPTION
# Summary

- made 'branch' a property, which checks if the self._branch attribute exists, if not it will fetch or create the branch, and then return self._branch
- also added a setter, so the self.branch attribute can be set
- reduced code duplication between from_rid and from_path by extending the `switch_branch` method

# Checklist

- [x] You agree with our [CLA](https://gist.githubusercontent.com/emdgroup-admin/16cc45ea4315c2ef29eb9d9afc36fcf5/raw/abb9c91f15278a62b9ac3e66144bcd27fa9485c2/CLA.md)
- [x] Included tests (or is not applicable).
- [x] Updated [documentation](https://emdgroup.github.io/foundry-dev-tools/) (or is not applicable).
- [x] Used [pre-commit hooks](https://emdgroup.github.io/foundry-dev-tools/develop.html#pre-commit-hooks-formatting) to format and lint the code.
