### PR TITLE
fix: updated file downloading to download only files that do not exis…

### DIFF
--- a/libs/foundry-dev-tools/src/foundry_dev_tools/clients/data_proxy.py
+++ b/libs/foundry-dev-tools/src/foundry_dev_tools/clients/data_proxy.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import shutil
+import tempfile
 from concurrent.futures import ThreadPoolExecutor
 from functools import partial
 from itertools import repeat
@@ -258,6 +259,7 @@ class DataProxyClient(APIClient):
             Path: local file path
         """
         local_path = output_directory.joinpath(foundry_file_path)
+
         local_path.parent.mkdir(exist_ok=True, parents=True)
         if local_path.exists():
             return local_path
@@ -267,10 +269,11 @@ class DataProxyClient(APIClient):
             foundry_file_path,
             stream=True,
         )
-        with local_path.open(mode="wb+") as out_file:
+
+        with tempfile.NamedTemporaryFile(mode='wb+') as out_file:
             resp.raw.decode_content = True
             shutil.copyfileobj(resp.raw, out_file)
-
+        shutil.move(out_file.name, local_path)
         return local_path
 
     def download_dataset_files(

--- a/libs/foundry-dev-tools/src/foundry_dev_tools/clients/data_proxy.py
+++ b/libs/foundry-dev-tools/src/foundry_dev_tools/clients/data_proxy.py
@@ -259,6 +259,8 @@ class DataProxyClient(APIClient):
         """
         local_path = output_directory.joinpath(foundry_file_path)
         local_path.parent.mkdir(exist_ok=True, parents=True)
+        if local_path.exists():
+            return local_path
         resp = self.api_get_file_in_view(
             dataset_rid,
             view,


### PR DESCRIPTION

# Summary

Downloads only partitions of the file that are not existing - it helps when I am on slow corporate vpn and trying to download semi-big dataset

# Checklist

- [v] You agree with our [CLA](https://gist.githubusercontent.com/emdgroup-admin/16cc45ea4315c2ef29eb9d9afc36fcf5/raw/abb9c91f15278a62b9ac3e66144bcd27fa9485c2/CLA.md)
- [v] Included tests (or is not applicable).
- [v] Updated [documentation](https://emdgroup.github.io/foundry-dev-tools/) (or is not applicable).
- [v] Used [pre-commit hooks](https://emdgroup.github.io/foundry-dev-tools/develop.html#pre-commit-hooks-formatting) to format and lint the code.
