### PR TITLE
fix: Resource can tolerate new JSON properties being introduced

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog],
 and this project adheres to [Semantic Versioning].
 
+## [2.1.8] - 2024-09-25
+
+## Fixed
+  - fix Resource class can tolerate new Compass JSON Properties (#75)
+
 ## [2.1.7] - 2024-09-16
 
 ## Fixed
@@ -286,6 +291,7 @@ and this project adheres to [Semantic Versioning].
 [Keep a Changelog]: https://keepachangelog.com/en/1.0.0/
 [Semantic Versioning]: https://semver.org/spec/v2.0.0.html
 
+[2.1.8]: https://github.com/emdgroup/foundry-dev-tools/compare/v2.1.7...v2.1.8
 [2.1.7]: https://github.com/emdgroup/foundry-dev-tools/compare/v2.1.6...v2.1.7
 [2.1.6]: https://github.com/emdgroup/foundry-dev-tools/compare/v2.1.5...v2.1.6
 [2.1.5]: https://github.com/emdgroup/foundry-dev-tools/compare/v2.1.4...v2.1.5

--- a/libs/foundry-dev-tools/src/foundry_dev_tools/resources/resource.py
+++ b/libs/foundry-dev-tools/src/foundry_dev_tools/resources/resource.py
@@ -114,6 +114,7 @@ class Resource:
         disableInheritedPermissions: api_types.DisableInheritedPermissionsType | None = None,  # noqa: N803
         propagatePermissions: bool | None = None,  # noqa: N803
         resourceLevelRoleGrantsAllowed: bool | None = None,  # noqa: N803
+        **kwargs,
     ):
         self.rid = rid
         self.name = name
@@ -153,6 +154,7 @@ class Resource:
         self.disable_inherited_permissions = disableInheritedPermissions
         self.propagate_permissions = propagatePermissions
         self.resource_level_role_grants_allowed = resourceLevelRoleGrantsAllowed
+        self._kwargs = kwargs
 
     @classmethod
     def _create_class(

--- a/tests/unit/resources/test_resource.py
+++ b/tests/unit/resources/test_resource.py
@@ -49,7 +49,60 @@ def test_wrong_resource_type(test_context_mock):
             "disableInheritedPermissions": None,
             "propagatePermissions": None,
             "resourceLevelRoleGrantsAllowed": None,
+            "portfolioRid": None,
         },
     )
     with pytest.raises(WrongResourceTypeError):
         test_context_mock.get_dataset("ri.foundry.main.folder.1234")
+
+
+def test_additional_property_in_resource_json(test_context_mock):
+    test_context_mock.mock_adapter.register_uri(
+        "GET",
+        re.compile(re.escape(build_api_url(test_context_mock.token_provider.host.url, "compass", "")) + "resources/*"),
+        json={
+            "rid": "ri.foundry.main.folder.1234",
+            "name": "just_a_name",
+            "created": {"time": "2024-08-28T06:54:49.569854929Z", "userId": "1234"},
+            "modified": {"time": "2024-08-28T06:57:20.413795158Z", "userId": "1234"},
+            "lastModified": 1724828240413.0,
+            "description": None,
+            "operations": [
+                "compass:edit-project",
+            ],
+            "urlVariables": {"compass:isProject": "false"},
+            "favorite": None,
+            "branches": None,
+            "defaultBranch": None,
+            "defaultBranchWithMarkings": None,
+            "branchesCount": None,
+            "hasBranches": None,
+            "hasMultipleBranches": None,
+            "backedObjectTypes": None,
+            "path": "/some/path",
+            "longDescription": None,
+            "directlyTrashed": False,
+            "inTrash": False,
+            "isAutosave": False,
+            "isHidden": False,
+            "deprecation": None,
+            "collections": None,
+            "namedCollections": None,
+            "tags": None,
+            "namedTags": None,
+            "alias": None,
+            "collaborators": None,
+            "namedAncestors": None,
+            "markings": None,
+            "projectAccessMarkings": None,
+            "linkedItems": None,
+            "contactInformation": None,
+            "classification": None,
+            "disableInheritedPermissions": None,
+            "propagatePermissions": None,
+            "resourceLevelRoleGrantsAllowed": None,
+            "portfolioRid": None,
+        },
+    )
+    # fixes TypeError: Resource._from_json() got an unexpected keyword argument 'portfolioRid'
+    test_context_mock.get_resource("ri.foundry.main.folder.1234")


### PR DESCRIPTION
# Summary

There is new portfolioRid property being responded by the compass API and the current code can not handle it.

# Checklist

- [x] You agree with our [CLA](https://gist.githubusercontent.com/emdgroup-admin/16cc45ea4315c2ef29eb9d9afc36fcf5/raw/abb9c91f15278a62b9ac3e66144bcd27fa9485c2/CLA.md)
- [x] Included tests (or is not applicable).
- [x] Updated [documentation](https://emdgroup.github.io/foundry-dev-tools/) (or is not applicable).
- [x] Used [pre-commit hooks](https://emdgroup.github.io/foundry-dev-tools/develop.html#pre-commit-hooks-formatting) to format and lint the code.
