### PR TITLE
Allow importing Transform directly from transforms.api

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog],
 and this project adheres to [Semantic Versioning].
 
+## [2.1.9] - 2024-10-08
+
+## Changed
+  - Allow direct import of `Transform` from `transforms.api`
+
 ## [2.1.8] - 2024-09-25
 
 ## Fixed
@@ -291,6 +296,7 @@ and this project adheres to [Semantic Versioning].
 [Keep a Changelog]: https://keepachangelog.com/en/1.0.0/
 [Semantic Versioning]: https://semver.org/spec/v2.0.0.html
 
+[2.1.9]: https://github.com/emdgroup/foundry-dev-tools/compare/v2.1.8...v2.1.9
 [2.1.8]: https://github.com/emdgroup/foundry-dev-tools/compare/v2.1.7...v2.1.8
 [2.1.7]: https://github.com/emdgroup/foundry-dev-tools/compare/v2.1.6...v2.1.7
 [2.1.6]: https://github.com/emdgroup/foundry-dev-tools/compare/v2.1.5...v2.1.6

--- a/libs/transforms/src/transforms/api/__init__.py
+++ b/libs/transforms/src/transforms/api/__init__.py
@@ -15,19 +15,20 @@ from transforms.api._decorators import (
     transform_pandas,
     transform_polars,
 )
-from transforms.api._transform import TransformContext
+from transforms.api._transform import Transform, TransformContext
 
 __all__ = (
     "Input",
     "Output",
     "Markings",
     "OrgMarkings",
+    "configure",
+    "incremental",
+    "lightweight",
+    "transform",
     "transform_df",
     "transform_pandas",
-    "transform",
-    "lightweight",
     "transform_polars",
+    "Transform",
     "TransformContext",
-    "incremental",
-    "configure",
 )


### PR DESCRIPTION
# Summary

I want to type hint a function that dynamically generates a list of transforms and I want to directly import `from transforms.api import Transform` while working locally, similar to how you can import it that way within the foundry code repository web UI.

Currently the **Desired implementation** will throw an error locally but work fine on foundry code repositories web UI.

## Current implementation

```python
from transforms.api import (
    Input,
    Output,
    configure,
    incremental,
    lightweight,
    transform,
)
from transforms.api._transform import Transform

def create_dynamic_transforms() -> List[Transform]:
    """Dynamically generate transforms for all pipelines.

    Returns:
        List[Transform]: List of transform functions with inputs/outputs
            defined for foundry to process.
    """
    results = []
    ...
```

## Desired implementation

```python
from transforms.api import (
    Input,
    Output,
    Transform,  # <--
    configure,
    incremental,
    lightweight,
    transform,
)

def create_dynamic_transforms() -> List[Transform]:
    """Dynamically generate transforms for all pipelines.

    Returns:
        List[Transform]: List of transform functions with inputs/outputs
            defined for foundry to process.
    """
    results = []
    ...
```

# Checklist

- [x] You agree with our [CLA](https://gist.githubusercontent.com/emdgroup-admin/16cc45ea4315c2ef29eb9d9afc36fcf5/raw/abb9c91f15278a62b9ac3e66144bcd27fa9485c2/CLA.md)
- [x] Included tests (or is not applicable).
- [x] Updated [documentation](https://emdgroup.github.io/foundry-dev-tools/) (or is not applicable).
- [x] Used [pre-commit hooks](https://emdgroup.github.io/foundry-dev-tools/develop.html#pre-commit-hooks-formatting) to format and lint the code.
