### PR TITLE
Add typing to callables in transform decorators

### DIFF
--- a/libs/transforms/src/transforms/api/_decorators.py
+++ b/libs/transforms/src/transforms/api/_decorators.py
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
 
     import pandas as pd
     import polars as pl
+    import pyspark.sql
 
 
 def lightweight(
@@ -157,7 +158,7 @@ def transform_polars(output: Output, **inputs: Input) -> Callable[[Callable[...,
     return _transform_polars
 
 
-def transform_df(output: Output, **inputs: Input) -> Callable[[Callable], Transform]:
+def transform_df(output: Output, **inputs: Input) -> Callable[[Callable[..., pyspark.sql.DataFrame]], Transform]:
     """Register the wrapped compute function as a dataframe transform.
 
     The ``transform_df`` decorator is used to construct a :class:`Transform` object from
@@ -183,7 +184,7 @@ def transform_df(output: Output, **inputs: Input) -> Callable[[Callable], Transf
         **inputs (Input): kwargs comprised of named :class:`Input` specs.
     """
 
-    def _transform_df(compute_func: Callable) -> Transform:
+    def _transform_df(compute_func: Callable[..., pyspark.sql.DataFrame]) -> Transform:
         return Transform(compute_func, {"output": output}, inputs=inputs, decorator="spark")
 
     return _transform_df

--- a/libs/transforms/src/transforms/api/_decorators.py
+++ b/libs/transforms/src/transforms/api/_decorators.py
@@ -16,6 +16,8 @@ from transforms.api._transform import Transform
 if TYPE_CHECKING:
     from collections.abc import Callable
 
+    import polars as pl
+
 
 def lightweight(
     _maybe_transform: Transform | None = None,
@@ -113,7 +115,7 @@ def lightweight(
     return _lightweight if _maybe_transform is None else _lightweight(_maybe_transform)
 
 
-def transform_polars(output: Output, **inputs: Input) -> Callable[[Callable], Transform]:
+def transform_polars(output: Output, **inputs: Input) -> Callable[[Callable[..., pl.DataFrame]], Transform]:
     """Register the wrapped compute function as a Polars transform.
 
     Note:
@@ -143,7 +145,7 @@ def transform_polars(output: Output, **inputs: Input) -> Callable[[Callable], Tr
         **inputs (Input): kwargs comprised of named :class:`Input` specs.
     """
 
-    def _transform_polars(compute_function: Callable) -> Transform:
+    def _transform_polars(compute_function: Callable[..., pl.DataFrame]) -> Transform:
         return Transform(
             compute_function,
             outputs={"output": output},

--- a/libs/transforms/src/transforms/api/_decorators.py
+++ b/libs/transforms/src/transforms/api/_decorators.py
@@ -16,6 +16,7 @@ from transforms.api._transform import Transform
 if TYPE_CHECKING:
     from collections.abc import Callable
 
+    import pandas as pd
     import polars as pl
 
 
@@ -188,7 +189,7 @@ def transform_df(output: Output, **inputs: Input) -> Callable[[Callable], Transf
     return _transform_df
 
 
-def transform_pandas(output: Output, **inputs: Input) -> Callable[[Callable], Transform]:
+def transform_pandas(output: Output, **inputs: Input) -> Callable[[Callable[..., pd.DataFrame]], Transform]:
     """Register the wrapped compute function as a Pandas transform.
 
     The ``transform_pandas`` decorator is used to construct a :class:`Transform` object from
@@ -213,7 +214,7 @@ def transform_pandas(output: Output, **inputs: Input) -> Callable[[Callable], Tr
         **inputs (Input): kwargs comprised of named :class:`Input` specs.
     """
 
-    def _transform_pandas(compute_func: Callable) -> Transform:
+    def _transform_pandas(compute_func: Callable[..., pd.DataFrame]) -> Transform:
         return Transform(compute_func, {"output": output}, inputs=inputs, decorator="pandas")
 
     return _transform_pandas

--- a/libs/transforms/src/transforms/api/_decorators.py
+++ b/libs/transforms/src/transforms/api/_decorators.py
@@ -113,7 +113,7 @@ def lightweight(
     return _lightweight if _maybe_transform is None else _lightweight(_maybe_transform)
 
 
-def transform_polars(output: Output, **inputs) -> Callable[[Callable], Transform]:
+def transform_polars(output: Output, **inputs: Input) -> Callable[[Callable], Transform]:
     """Register the wrapped compute function as a Polars transform.
 
     Note:
@@ -154,7 +154,7 @@ def transform_polars(output: Output, **inputs) -> Callable[[Callable], Transform
     return _transform_polars
 
 
-def transform_df(output: Output, **inputs) -> Callable[[Callable], Transform]:
+def transform_df(output: Output, **inputs: Input) -> Callable[[Callable], Transform]:
     """Register the wrapped compute function as a dataframe transform.
 
     The ``transform_df`` decorator is used to construct a :class:`Transform` object from
@@ -186,7 +186,7 @@ def transform_df(output: Output, **inputs) -> Callable[[Callable], Transform]:
     return _transform_df
 
 
-def transform_pandas(output: Output, **inputs) -> Callable[[Callable], Transform]:
+def transform_pandas(output: Output, **inputs: Input) -> Callable[[Callable], Transform]:
     """Register the wrapped compute function as a Pandas transform.
 
     The ``transform_pandas`` decorator is used to construct a :class:`Transform` object from

--- a/libs/transforms/src/transforms/api/_decorators.py
+++ b/libs/transforms/src/transforms/api/_decorators.py
@@ -221,7 +221,7 @@ def transform_pandas(output: Output, **inputs: Input) -> Callable[[Callable[...,
     return _transform_pandas
 
 
-def transform(**kwargs) -> Callable[[Callable[..., None]], Transform]:
+def transform(**kwargs: Input | Output) -> Callable[[Callable[..., None]], Transform]:
     """Wrap up a compute function as a Transform object.
 
     >>> from transforms.api import transform, Input, Output

--- a/libs/transforms/src/transforms/api/_decorators.py
+++ b/libs/transforms/src/transforms/api/_decorators.py
@@ -221,7 +221,7 @@ def transform_pandas(output: Output, **inputs: Input) -> Callable[[Callable[...,
     return _transform_pandas
 
 
-def transform(**kwargs) -> Callable[[Callable], Transform]:
+def transform(**kwargs) -> Callable[[Callable[..., None]], Transform]:
     """Wrap up a compute function as a Transform object.
 
     >>> from transforms.api import transform, Input, Output
@@ -243,7 +243,7 @@ def transform(**kwargs) -> Callable[[Callable], Transform]:
         The compute function is responsible for writing data to its outputs.
     """
 
-    def _transform(compute_func: Callable) -> Transform:
+    def _transform(compute_func: Callable[..., None]) -> Transform:
         return Transform(
             compute_func,
             outputs={k: v for k, v in kwargs.items() if isinstance(v, Output)},


### PR DESCRIPTION
# Summary

Hello!

We are utilising foundry-dev-tools for some local development, primarily for the added type hints when using transforms.

We use the "strict=True" option for mypy type checking during our development. This setting disallows unspecified Callable types as an error when checking types. I added more specific gradual types to the "transformation_polars" and "transformation_pandas" decorators so that mypy is satisfied.

I suspect that the same type hints could be added for the pyspark transforms aswell. I can add that to this PR if that is desirable.

In the process, I also added the "Input" type to the **kwargs in the decorator signature. If required I could split that into a separate PR.

Best regards,
Jim

# Checklist

- [x] You agree with our [CLA](https://gist.githubusercontent.com/emdgroup-admin/16cc45ea4315c2ef29eb9d9afc36fcf5/raw/abb9c91f15278a62b9ac3e66144bcd27fa9485c2/CLA.md)
- [x] Included tests (or is not applicable).
- [x] Updated [documentation](https://emdgroup.github.io/foundry-dev-tools/) (or is not applicable).
- [x] Used [pre-commit hooks](https://emdgroup.github.io/foundry-dev-tools/develop.html#pre-commit-hooks-formatting) to format and lint the code.
