### PR TITLE
Add direct polars support to dataset class

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -305,7 +305,7 @@ and this project adheres to [Semantic Versioning].
 [Keep a Changelog]: https://keepachangelog.com/en/1.0.0/
 [Semantic Versioning]: https://semver.org/spec/v2.0.0.html
 
-[2.1.9]: https://github.com/emdgroup/foundry-dev-tools/compare/v2.1.9...v2.1.10
+[2.1.10]: https://github.com/emdgroup/foundry-dev-tools/compare/v2.1.9...v2.1.10
 [2.1.9]: https://github.com/emdgroup/foundry-dev-tools/compare/v2.1.8...v2.1.9
 [2.1.8]: https://github.com/emdgroup/foundry-dev-tools/compare/v2.1.7...v2.1.8
 [2.1.7]: https://github.com/emdgroup/foundry-dev-tools/compare/v2.1.6...v2.1.7

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog],
 and this project adheres to [Semantic Versioning].
 
+## [2.1.10] - 2024-10-31
+
+## Changed
+  - Typing for callable in transform decorators (#78)
+  - Support polars in Dataset class (#81)
+
+## Added
+  - Update project roles via compass-API (#80)
+  
 ## [2.1.9] - 2024-10-08
 
 ## Changed
@@ -296,6 +305,7 @@ and this project adheres to [Semantic Versioning].
 [Keep a Changelog]: https://keepachangelog.com/en/1.0.0/
 [Semantic Versioning]: https://semver.org/spec/v2.0.0.html
 
+[2.1.9]: https://github.com/emdgroup/foundry-dev-tools/compare/v2.1.9...v2.1.10
 [2.1.9]: https://github.com/emdgroup/foundry-dev-tools/compare/v2.1.8...v2.1.9
 [2.1.8]: https://github.com/emdgroup/foundry-dev-tools/compare/v2.1.7...v2.1.8
 [2.1.7]: https://github.com/emdgroup/foundry-dev-tools/compare/v2.1.6...v2.1.7

--- a/libs/foundry-dev-tools/src/foundry_dev_tools/resources/dataset.py
+++ b/libs/foundry-dev-tools/src/foundry_dev_tools/resources/dataset.py
@@ -565,9 +565,10 @@ class Dataset(resource.Resource):
             # to be backwards compatible to most readers, that expect files
             # to be under spark/
             folder = str(round(time.time() * 1000)) if transaction_type == "APPEND" else "spark"
+            parquet_compression = "snappy"
+
             if not (pd.__fake__ or pl.__fake__) and isinstance(df, pd.DataFrame | pl.DataFrame):
                 buf = io.BytesIO()
-                parquet_compression = "snappy"
                 schema_flavor = "spark"
 
                 if isinstance(df, pd.DataFrame):
@@ -595,7 +596,7 @@ class Dataset(resource.Resource):
             else:
                 with tempfile.TemporaryDirectory() as path:
                     p_path = Path(path)
-                    df.write.format("parquet").option("compression", "snappy").save(
+                    df.write.format("parquet").option("compression", parquet_compression).save(
                         path=path,
                         mode="overwrite",
                     )

--- a/tests/integration/resources/test_dataset.py
+++ b/tests/integration/resources/test_dataset.py
@@ -1,6 +1,8 @@
 import pandas as pd
+import polars as pl
 import pytest
-from pandas.testing import assert_frame_equal
+from pandas.testing import assert_frame_equal as pd_assert_frame_equal
+from polars.testing import assert_frame_equal as pl_assert_frame_equal
 from pyspark.testing import assertDataFrameEqual
 
 from foundry_dev_tools.errors.compass import ResourceNotFoundError
@@ -85,11 +87,16 @@ def test_crud_dataset(spark_session, tmp_path):  # noqa: PLR0915
 
     # test save_dataframe
     df = pd.DataFrame({"a": [0], "b": [1]})
-    pd_spark_df = pd.DataFrame({"a": [1], "b": [0]})
+    polars_df = pl.DataFrame({"a": [1], "b": [2]})
+    pd_spark_df = pd.DataFrame({"a": [1], "b": [0]})  # create slightly different dataframe
     spark_df = spark_session.createDataFrame(pd_spark_df)  # create slightly different dataframe
 
     ds.save_dataframe(df)
-    assert_frame_equal(df, ds.to_pandas())
+    pd_assert_frame_equal(df, ds.to_pandas())
+
+    ds_polars_branch = TEST_SINGLETON.ctx.get_dataset(ds.rid, branch="polars")
+    ds_polars_branch.save_dataframe(polars_df)
+    pl_assert_frame_equal(polars_df, ds_polars_branch.to_polars())
 
     ds_spark_branch = TEST_SINGLETON.ctx.get_dataset(ds.rid, branch="spark")
     ds_spark_branch.save_dataframe(spark_df)


### PR DESCRIPTION
# Summary
While foundry-dev-tools and some [documented examples](https://emdgroup.github.io/foundry-dev-tools/examples/dataset.html#polars-dataframe-from-spark-sql-dialect) already make use of [Polars](https://pola.rs/), the 
[Dataset class](https://emdgroup.github.io/foundry-dev-tools/api/foundry_dev_tools.resources.dataset.html#foundry_dev_tools.resources.dataset.Dataset) is lacking a direct polars support by two means:

- [ds.to_XX()](https://emdgroup.github.io/foundry-dev-tools/api/foundry_dev_tools.resources.dataset.html#foundry_dev_tools.resources.dataset.Dataset.to_spark) only supports spark, arrow and pandas.
This requires a polars user to always go an intermediate step over arrow.

- [ds.save_dataframe(df)](https://emdgroup.github.io/foundry-dev-tools/api/foundry_dev_tools.resources.dataset.html#foundry_dev_tools.resources.dataset.Dataset.save_dataframe) only supports pandas and spark dataframes.
This is a limitation for polars users, as pyspark adds some overhead and polars_df.to_pandas() can cause undesired schema changes.


The PR hence proposes to add ds.to_polars() and to support polars dataframes in ds.save_dataframe().

# Checklist

- [x] You agree with our [CLA](https://gist.githubusercontent.com/emdgroup-admin/16cc45ea4315c2ef29eb9d9afc36fcf5/raw/abb9c91f15278a62b9ac3e66144bcd27fa9485c2/CLA.md)
- [x] Included tests (or is not applicable).
- [x] Updated [documentation](https://emdgroup.github.io/foundry-dev-tools/) (or is not applicable).
- [x] Used [pre-commit hooks](https://emdgroup.github.io/foundry-dev-tools/develop.html#pre-commit-hooks-formatting) to format and lint the code.
