### PR TITLE
fix: saving dataset via optional pandas / polars

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog],
 and this project adheres to [Semantic Versioning].
 
-## [Unreleased]
+## [2.1.11]
 
 ## Fixed
 - `save_dataframe` incorrectly interacting with optional modules pandas or polars
@@ -311,6 +311,7 @@ and this project adheres to [Semantic Versioning].
 [Keep a Changelog]: https://keepachangelog.com/en/1.0.0/
 [Semantic Versioning]: https://semver.org/spec/v2.0.0.html
 
+[2.1.11]: https://github.com/emdgroup/foundry-dev-tools/compare/v2.1.10...v2.1.11
 [2.1.10]: https://github.com/emdgroup/foundry-dev-tools/compare/v2.1.9...v2.1.10
 [2.1.9]: https://github.com/emdgroup/foundry-dev-tools/compare/v2.1.8...v2.1.9
 [2.1.8]: https://github.com/emdgroup/foundry-dev-tools/compare/v2.1.7...v2.1.8

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog],
 and this project adheres to [Semantic Versioning].
 
+## [Unreleased]
+
+## Fixed
+- `save_dataframe` incorrectly interacting with optional modules pandas or polars
+
 ## [2.1.10] - 2024-10-31
 
 ## Changed

--- a/libs/foundry-dev-tools/src/foundry_dev_tools/resources/dataset.py
+++ b/libs/foundry-dev-tools/src/foundry_dev_tools/resources/dataset.py
@@ -567,11 +567,13 @@ class Dataset(resource.Resource):
             folder = str(round(time.time() * 1000)) if transaction_type == "APPEND" else "spark"
             parquet_compression = "snappy"
 
-            if not (pd.__fake__ or pl.__fake__) and isinstance(df, pd.DataFrame | pl.DataFrame):
+            use_pandas = not pd.__fake__ and isinstance(df, pd.DataFrame)
+            use_polars = not pl.__fake__ and isinstance(df, pl.DataFrame)
+            if use_pandas or use_polars:
                 buf = io.BytesIO()
                 schema_flavor = "spark"
 
-                if isinstance(df, pd.DataFrame):
+                if use_pandas:
                     # write pandas dataframe as parquet to buffer
                     df.to_parquet(
                         buf,


### PR DESCRIPTION
# Summary

Discovered an issue in a project where I use `foundry-dev-tools` and `pandas` but not `polars`. I pass a `pd.DataFrame` to `Dataset.save_dataframe`.

## Expectation
Would expect that the dataset is written to the resource. I verified that the resource correctly exists and was created via `foundry_context.get_dataset_by_path`. I have also noticed that several weeks ago the bug did not exists, which coincides with the fact that `save_dataframe` was recently changed 1w ago in #81.

## Outcome
 ```terminal
    File "/Users/xxxxxx/Code/.../connector/foundry.py", line 159, in send_recommendations
      ds.save_dataframe(recommendations)
    File "/Users/xxxxxx/mambaforge/envs/.../lib/python3.10/site-packages/foundry_dev_tools/resources/dataset.py", line 599, in save_dataframe
      df.write.format("parquet").option("compression", parquet_compression).save(
    File "/Users/xxxxxx/mambaforge/envs/.../lib/python3.10/site-packages/pandas/core/generic.py", line 6299, in __getattr__
      return object.__getattribute__(self, name)
  AttributeError: 'DataFrame' object has no attribute 'write'
```

The [upper block](https://github.com/emdgroup/foundry-dev-tools/blob/main/libs/foundry-dev-tools/src/foundry_dev_tools/resources/dataset.py#L570) dealing with `pandas` and `polars` dfs was not executed, even though `pandas` is installed and a `pd.DataFrame` was passed. Instead the [lower block](https://github.com/emdgroup/foundry-dev-tools/blob/main/libs/foundry-dev-tools/src/foundry_dev_tools/resources/dataset.py#L596) trying to save the pandas dataframe via pyspark was executed, resulting in the error. It appears the if condition is not correct, basically it will execute the upper block only when both pandas and polars are installed. However, I would expect it to execute the upper block also when just one of the two is installed. 

## Fix
The simplest fix would be to turn
```python
not (pd.__fake__ or pl.__fake__)
```
into
```python
(not pd.__fake__ or not pl.__fake__)
```
or
```python
not (pd.__fake__ and pl.__fake__)
```

But then the subsequent `isinstance` checks could fail due to unavailable objects. The suggestion I made redesigns the if check and should also be safe when only one of the two optional packages is installed.

# Checklist

- [x] You agree with our [CLA](https://gist.githubusercontent.com/emdgroup-admin/16cc45ea4315c2ef29eb9d9afc36fcf5/raw/abb9c91f15278a62b9ac3e66144bcd27fa9485c2/CLA.md)
- [ ] Included tests (or is not applicable).
- [x] Updated [documentation](https://emdgroup.github.io/foundry-dev-tools/) (or is not applicable).
- [ ] Used [pre-commit hooks](https://emdgroup.github.io/foundry-dev-tools/develop.html#pre-commit-hooks-formatting) to format and lint the code.
