### PR TITLE
fix require consent param name, should be requireConsent instead of require_consent

### DIFF
--- a/libs/foundry-dev-tools/src/foundry_dev_tools/clients/multipass.py
+++ b/libs/foundry-dev-tools/src/foundry_dev_tools/clients/multipass.py
@@ -1192,7 +1192,7 @@ class MultipassClient(APIClient):
                 "resources": resources,
                 "markingIds": marking_ids,
                 "grantTypes": grant_types,
-                "require_consent": require_consent,
+                "requireConsent": require_consent,
             },
             **kwargs,
         )


### PR DESCRIPTION
# Summary

This PR fixes this issue #89 

Changed:

* [`libs/foundry-dev-tools/src/foundry_dev_tools/clients/multipass.py`](diffhunk://#diff-e8f57da5c340426d3fe6c2eee25021168e40a19906c902746e6d46bf30b48240L1195-R1195): Modified the key `require_consent` to `requireConsent` in the dictionary passed to the API. I verified this by inspecting the network request while doing same action from the control panel frontend.

# Checklist

- [x] You agree with our [CLA](https://gist.githubusercontent.com/emdgroup-admin/16cc45ea4315c2ef29eb9d9afc36fcf5/raw/abb9c91f15278a62b9ac3e66144bcd27fa9485c2/CLA.md)
- [x] Included tests (or is not applicable).
- [ ] Updated [documentation](https://emdgroup.github.io/foundry-dev-tools/) (or is not applicable).
- [x] Used [pre-commit hooks](https://emdgroup.github.io/foundry-dev-tools/develop.html#pre-commit-hooks-formatting) to format and lint the code.


