### PR TITLE
fix: establish direct read for full dataset queries in Dataset class

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog],
 and this project adheres to [Semantic Versioning].
 
+## [2.1.14] - 2024-12-18
+
+## Fixed
+- establish direct read for full dataset queries in Dataset class (#91)
+
 ## [2.1.13] - 2024-12-16
 
 ## Fixed
@@ -321,6 +326,7 @@ and this project adheres to [Semantic Versioning].
 [Keep a Changelog]: https://keepachangelog.com/en/1.0.0/
 [Semantic Versioning]: https://semver.org/spec/v2.0.0.html
 
+[2.1.14]: https://github.com/emdgroup/foundry-dev-tools/compare/v2.1.13...v2.1.14
 [2.1.13]: https://github.com/emdgroup/foundry-dev-tools/compare/v2.1.12...v2.1.13
 [2.1.12]: https://github.com/emdgroup/foundry-dev-tools/compare/v2.1.11...v2.1.12
 [2.1.11]: https://github.com/emdgroup/foundry-dev-tools/compare/v2.1.10...v2.1.11

--- a/libs/foundry-dev-tools/src/foundry_dev_tools/resources/dataset.py
+++ b/libs/foundry-dev-tools/src/foundry_dev_tools/resources/dataset.py
@@ -748,8 +748,12 @@ class Dataset(resource.Resource):
         >>> ds = ctx.get_dataset_by_path("/path/to/dataset")
         >>> ds.query_foundry_sql("SELECT * WHERE a=1")
         """  # noqa: E501
+        # This is a quick fix. Foundry Sql Server seems to decide that
+        # "FROM `rid` SELECT *" is not direct read eligible.
+        # tracking: ri.issues.main.issue.da8272ca-9e78-4100-af3f-6ac40aaecf51
+        query_string = f"SELECT * FROM `{self.rid}`" if query == "SELECT *" else f"FROM `{self.rid}` {query}"  # noqa: S608
         return self._context.foundry_sql_server.query_foundry_sql(
-            f"FROM `{self.rid}` {query}",
+            query=query_string,
             return_type=return_type,
             branch=self.branch["id"],
             sql_dialect=sql_dialect,


### PR DESCRIPTION
# Summary

- the Dataset class sends SQL Queries like "FROM `rid` SELECT *"
- Foundry SQL Server detects those as NOT eligible for direct reads
- Queries are slow and queries with result sets larger than 10Mio Rows fail with FoundrySqlServer:TooManyRows
- Tracking on the stack here ri.issues.main.issue.da8272ca-9e78-4100-af3f-6ac40aaecf51
- We add a workaround and hope the SQL Server Endpoint team can fix it.

# Checklist

- [x] You agree with our [CLA](https://gist.githubusercontent.com/emdgroup-admin/16cc45ea4315c2ef29eb9d9afc36fcf5/raw/abb9c91f15278a62b9ac3e66144bcd27fa9485c2/CLA.md)
- [ ] Included tests (or is not applicable).
- [ ] Updated [documentation](https://emdgroup.github.io/foundry-dev-tools/) (or is not applicable).
- [x] Used [pre-commit hooks](https://emdgroup.github.io/foundry-dev-tools/develop.html#pre-commit-hooks-formatting) to format and lint the code.
