### PR TITLE
added `api_get_table_schema` for TableClient

### DIFF
--- a/libs/foundry-dev-tools/src/foundry_dev_tools/clients/tables.py
+++ b/libs/foundry-dev-tools/src/foundry_dev_tools/clients/tables.py
@@ -144,12 +144,7 @@ class TablesClient(APIClient):
             tables.extend(response_json["tables"])
         return tables
 
-    def api_get_table_schema(
-        self,
-        table_rid: TableRid,
-        branches: list[Branch],
-        **kwargs
-    ) -> requests.Response:
+    def api_get_table_schema(self, table_rid: TableRid, branches: list[Branch], **kwargs) -> requests.Response:
         """Retrieves schema for a Foundry table object per given list of branches.
 
         Args:

--- a/libs/foundry-dev-tools/src/foundry_dev_tools/clients/tables.py
+++ b/libs/foundry-dev-tools/src/foundry_dev_tools/clients/tables.py
@@ -9,7 +9,7 @@ from foundry_dev_tools.clients.api_client import APIClient
 if TYPE_CHECKING:
     import requests
 
-    from foundry_dev_tools.utils.api_types import FolderRid, SourceRid, TableRid, Branch
+    from foundry_dev_tools.utils.api_types import Branch, FolderRid, SourceRid, TableRid
 
 
 class TablesClient(APIClient):
@@ -143,7 +143,7 @@ class TablesClient(APIClient):
             response_json = self.api_list_tables(connection_rid=connection_rid, page_token=next_page_token).json()
             tables.extend(response_json["tables"])
         return tables
-    
+
     def api_get_table_schema(
         self,
         table_rid: TableRid,
@@ -159,7 +159,7 @@ class TablesClient(APIClient):
 
         Returns:
             requests.Response: The API response containing the table schema.
-        
+
         Example::
             >>> response = tables_client.api_get_table_schema("ri.foundry.main.dataset.abc123", ["master"])
             >>> schema = response.json()

--- a/libs/foundry-dev-tools/src/foundry_dev_tools/clients/tables.py
+++ b/libs/foundry-dev-tools/src/foundry_dev_tools/clients/tables.py
@@ -9,7 +9,7 @@ from foundry_dev_tools.clients.api_client import APIClient
 if TYPE_CHECKING:
     import requests
 
-    from foundry_dev_tools.utils.api_types import FolderRid, SourceRid
+    from foundry_dev_tools.utils.api_types import FolderRid, SourceRid, TableRid, Branch
 
 
 class TablesClient(APIClient):
@@ -143,3 +143,26 @@ class TablesClient(APIClient):
             response_json = self.api_list_tables(connection_rid=connection_rid, page_token=next_page_token).json()
             tables.extend(response_json["tables"])
         return tables
+    
+    def api_get_table_schema(
+        self,
+        table_rid: TableRid,
+        branches: list[Branch],
+        **kwargs
+    ) -> requests.Response:
+        """Retrieves schema for a Foundry table object per given list of branches.
+
+        Args:
+            table_rid: The RID of the table to get schema for.
+            branches: List of branch names to get schema for.
+            **kwargs: gets passed to :py:meth:`APIClient.api_request`
+
+        Returns:
+            requests.Response: The API response containing the table schema.
+        """
+        return self.api_request(
+            "POST",
+            api_path=f"tables/{table_rid}/schema",
+            json={"branches": branches},
+            **kwargs,
+        )

--- a/libs/foundry-dev-tools/src/foundry_dev_tools/clients/tables.py
+++ b/libs/foundry-dev-tools/src/foundry_dev_tools/clients/tables.py
@@ -159,6 +159,29 @@ class TablesClient(APIClient):
 
         Returns:
             requests.Response: The API response containing the table schema.
+        
+        Example::
+            >>> response = tables_client.api_get_table_schema("ri.foundry.main.dataset.abc123", ["master"])
+            >>> schema = response.json()
+            >>> schema
+            {
+                "fieldSchemaList": [
+                    {
+                        "type": "DECIMAL",
+                        "name": "column_A",
+                        "nullable": false,
+                        "precision": 38,
+                        "scale": 0
+                    },
+                    {
+                        "type": "STRING",
+                        "name": "column_B",
+                        "nullable": false
+                    }
+                ],
+                "primaryKey": null,
+                "customMetadata": {"format": "snowflake"}
+            }
         """
         return self.api_request(
             "POST",


### PR DESCRIPTION
# Summary

Adding a *tested* code snipper, which retrieves Foundry Table's schema via the `tables` API service.

The image below shows a successful attempt achieved on Foundry:
![image](https://github.com/user-attachments/assets/8bd2bc1a-e579-4e66-9a1b-2aa844fac998)


# Checklist

- [X] You agree with our [CLA](https://gist.githubusercontent.com/emdgroup-admin/16cc45ea4315c2ef29eb9d9afc36fcf5/raw/abb9c91f15278a62b9ac3e66144bcd27fa9485c2/CLA.md)
- [X] Included tests (or is not applicable).
- [X] Updated [documentation](https://emdgroup.github.io/foundry-dev-tools/) (or is not applicable).
- [X] Used [pre-commit hooks](https://emdgroup.github.io/foundry-dev-tools/develop.html#pre-commit-hooks-formatting) to format and lint the code.
