### PR TITLE
`Build2Client` - JobSpec obtain & remove functions

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog],
 and this project adheres to [Semantic Versioning].
 
+## [2.1.19] - 2025-07-14
+
+## Added 
+- added api_remove_jobspecs and api_get_jobspec_for_dataset for Build2Client (#105)
+
 ## [2.1.18] - 2025-06-23
 
 ## Added 
@@ -354,6 +359,7 @@ and this project adheres to [Semantic Versioning].
 [Keep a Changelog]: https://keepachangelog.com/en/1.0.0/
 [Semantic Versioning]: https://semver.org/spec/v2.0.0.html
 
+[2.1.19]: https://github.com/emdgroup/foundry-dev-tools/compare/v2.1.18...v2.1.19
 [2.1.18]: https://github.com/emdgroup/foundry-dev-tools/compare/v2.1.17...v2.1.18
 [2.1.17]: https://github.com/emdgroup/foundry-dev-tools/compare/v2.1.16...v2.1.17
 [2.1.16]: https://github.com/emdgroup/foundry-dev-tools/compare/v2.1.15...v2.1.16

--- a/libs/foundry-dev-tools/src/foundry_dev_tools/clients/build2.py
+++ b/libs/foundry-dev-tools/src/foundry_dev_tools/clients/build2.py
@@ -244,7 +244,7 @@ class Build2Client(APIClient):
         branch: api_types.DatasetBranch = "master",
         branch_fallbacks: set[api_types.DatasetBranch] | None = None,
         **kwargs,
-    ) -> dict | None:
+    ) -> requests.Response:
         """Get the jobspec for a dataset.
 
         Args:
@@ -254,7 +254,8 @@ class Build2Client(APIClient):
             **kwargs: Passed to APIClient.api_request.
 
         Returns:
-            dict or None: Jobspec information, or None if not found.
+            requests.Response:
+                the response contains a json with detailed JobSpec information.
         """
         body = {
             "datasetRid": dataset_rid,
@@ -262,22 +263,19 @@ class Build2Client(APIClient):
             "branchFallbacks": {"branches": list(branch_fallbacks) if branch_fallbacks else []},
         }
 
-        response = self.api_request(
+        return self.api_request(
             "POST",
             "jobspecs/get-jobspec-for-dataset",
             json=body,
             error_handling=ErrorHandlingConfig({204: ResourceNotFoundError}),
             **kwargs,
         )
-        if response.status_code == 204:
-            return None
-        return response.json()
 
     def api_remove_jobspecs(
         self,
         jobspec_rids: list[api_types.JobSpecRid],
         **kwargs,
-    ) -> bool:
+    ) -> requests.Response:
         """Remove job specs by RID.
 
         Args:
@@ -285,14 +283,14 @@ class Build2Client(APIClient):
             **kwargs: Passed to APIClient.api_request.
 
         Returns:
-            bool: True if successful, False otherwise.
+            requests.Response:
+                the response will have no content if successful.
         """
         body = {"jobSpecRids": jobspec_rids}
 
-        response = self.api_request(
+        return self.api_request(
             "POST",
             "jobspecs/remove-jobspecs",
             json=body,
             **kwargs,
         )
-        return response.ok


### PR DESCRIPTION
…build2 client

# Summary
Adding two more function to the `Build2Client`:
- `api_get_jobspec_for_dataset` - retrieves complete JobSpec information for a given `dataset_rid` and `branch`
- `api_remove_jobspecs` - removes JobSpec information for a list of RIDs called `jobspec_rids`

The logic has been tested directly on Foundry's environment.
<img width="1059" height="747" alt="image" src="https://github.com/user-attachments/assets/67f54a0d-f5bd-41d0-aca1-0a132004bd5a" />

# Checklist

- [X] You agree with our [CLA](https://gist.githubusercontent.com/emdgroup-admin/16cc45ea4315c2ef29eb9d9afc36fcf5/raw/abb9c91f15278a62b9ac3e66144bcd27fa9485c2/CLA.md)
- [X] Included tests (or is not applicable).
- [X] Updated [documentation](https://emdgroup.github.io/foundry-dev-tools/) (or is not applicable).
- [X] Used [pre-commit hooks](https://emdgroup.github.io/foundry-dev-tools/develop.html#pre-commit-hooks-formatting) to format and lint the code.
