### PR TITLE
`MagritteCoordinatorClient` - Create new export from a source functionality

### DIFF
--- a/libs/foundry-dev-tools/src/foundry_dev_tools/clients/magritte_coordinator.py
+++ b/libs/foundry-dev-tools/src/foundry_dev_tools/clients/magritte_coordinator.py
@@ -220,9 +220,11 @@ class MagritteCoordinatorClient(APIClient):
         extract_name: str,
         transaction_type: TransactionType,
         source_adapter: dict,
-        spark_profiles: list | None = None,
+        spark_profiles: list[str] | None = None,
     ) -> str:
         r"""Creates a new Foundry extract from a given source.
+
+        The `.json()` at the end does return a string value and not a dict-like structure.
 
         Usage:
         ```python
@@ -240,7 +242,8 @@ class MagritteCoordinatorClient(APIClient):
         ...                 "sqlQuery": "SELECT * FROM \"AIRPORT_DB\".\"FLIGHTS\""
         ...             },
         ...         }
-        ...     }
+        ...     },
+        ...     spark_profiles=[]  # only work with a non-agent type of exports
         ... )
         ```
 
@@ -250,19 +253,27 @@ class MagritteCoordinatorClient(APIClient):
             source_rid: Source RID from which the extract/sync will be spawned from.
             extract_name: Name of the new extract/sync.
             transaction_type: One of the options available within `TransactionType`
-            source_adapter: example
-                {
-                    "type": "jdbc-source-adapter",
-                    "jdbcOptions": {
-                        "preQueries": [],
-                        "query": {
-                            "sqlQuery": "SELECT * FROM \"AIRPORT_DB\".\"FLIGHTS\""
+            source_adapter: Dictionary specifying the source adapter configuration. Must include:
+                - type (str): Adapter type, e.g., "jdbc-source-adapter".
+                - jdbcOptions (dict, optional): For JDBC adapters, must include:
+                    - preQueries (list[str]): List of SQL queries to run before main query.
+                    - query (dict): Must include:
+                        - sqlQuery (str): The SQL query to execute.
+                - Example:
+                    {
+                        "type": "jdbc-source-adapter",
+                        "jdbcOptions": {
+                            "preQueries": [],
+                            "query": {
+                                "sqlQuery": "SELECT * FROM \"AIRPORT_DB\".\"FLIGHTS\""
+                            }
+                        }
                     }
-                }
-            spark_profiles: A set of spark profiles to use. Not available when using agent-based extracts.
+            spark_profiles: list[str]. A list of spark profile names to use.
+                Not available when using agent-based extracts.
 
         Returns:
-            str
+            str: The extract RID of the newly created extract.
         """
         payload = {
             "datasetId": dataset_rid,


### PR DESCRIPTION
# Summary
Adding two new functions for the `MagritteCoordinatorClient`:
- `api_add_extract_for_branch` - returns a basic `request.Response`  from POST "build/add-extract?branchName={branch_name}".
- `create_new_extract_for_source` - a wrapper for the function above which returns a `str` value of the newly created extract/source RID.

Attaching three screenshots from my Foundry ecosystem proving that I was able to obtain a single new extract/source RID using the `create_new_extract_for_source` function & how such newly created sync looks like.

1. Getting the export/sync RID in-code (during a debug session):
<img width="766" height="434" alt="source_rid_retrieved" src="https://github.com/user-attachments/assets/6f667e46-dedb-4d94-91e8-d9a3ecd43dfb" />

2. Overview of the new export present within the source object on Foundry:
<img width="1420" height="1024" alt="export_1" src="https://github.com/user-attachments/assets/f31ed896-cbad-4268-9d9f-ab1e94c6f784" />

3. New export RID matches the one obtained in code:
<img width="1428" height="529" alt="export_2" src="https://github.com/user-attachments/assets/b7811f4d-76d5-417a-8c79-003cad7442cb" />


# Checklist

- [X] You agree with our [CLA](https://gist.githubusercontent.com/emdgroup-admin/16cc45ea4315c2ef29eb9d9afc36fcf5/raw/abb9c91f15278a62b9ac3e66144bcd27fa9485c2/CLA.md)
- [X] Included tests (or is not applicable).
- [X] Updated [documentation](https://emdgroup.github.io/foundry-dev-tools/) (or is not applicable).
- [X] Used [pre-commit hooks](https://emdgroup.github.io/foundry-dev-tools/develop.html#pre-commit-hooks-formatting) to format and lint the code.
