### PR TITLE
`MagritteCoordinatorClient` - add extract deletion

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog],
 and this project adheres to [Semantic Versioning].
 
+## [2.1.20] - 2025-10-24
+
+## Added
+- add new extract/sync creation for MagritteCoordinatorClient. (#109)
+- add extract/sync deletion for MagritteCoordinatorClient. (#110)
+
 ## [2.1.19] - 2025-07-14
 
 ## Added 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -365,6 +365,7 @@ and this project adheres to [Semantic Versioning].
 [Keep a Changelog]: https://keepachangelog.com/en/1.0.0/
 [Semantic Versioning]: https://semver.org/spec/v2.0.0.html
 
+[2.1.20]: https://github.com/emdgroup/foundry-dev-tools/compare/v2.1.19...v2.1.20
 [2.1.19]: https://github.com/emdgroup/foundry-dev-tools/compare/v2.1.18...v2.1.19
 [2.1.18]: https://github.com/emdgroup/foundry-dev-tools/compare/v2.1.17...v2.1.18
 [2.1.17]: https://github.com/emdgroup/foundry-dev-tools/compare/v2.1.16...v2.1.17

--- a/libs/foundry-dev-tools/src/foundry_dev_tools/clients/magritte_coordinator.py
+++ b/libs/foundry-dev-tools/src/foundry_dev_tools/clients/magritte_coordinator.py
@@ -12,6 +12,7 @@ if TYPE_CHECKING:
     from foundry_dev_tools.utils.api_types import (
         CodeResourceType,
         DatasetRid,
+        ExtractRid,
         FolderRid,
         MarkingId,
         NetworkEgressPolicyRid,
@@ -171,6 +172,17 @@ class MagritteCoordinatorClient(APIClient):
             parent_rid=parent_rid,
         )
         return response.json()
+
+    def api_delete_extract(self, extract_rid: ExtractRid, **kwargs) -> requests.Response:
+        """Pernamently deletes given magritte extract.
+
+        If successful, HTTP 204 status code is returned (no content).
+
+        Args:
+            extract_rid: Rid of the desired extract/sync to be deleted.
+            **kwargs: gets passed to :py:meth:`APIClient.api_request`
+        """
+        return self.api_request("DELETE", f"build/delete-extract/{extract_rid}", **kwargs)
 
     def get_source_config(self, source_rid: SourceRid) -> dict:
         """Returns the configuration of a Source."""

--- a/libs/foundry-dev-tools/src/foundry_dev_tools/utils/api_types.py
+++ b/libs/foundry-dev-tools/src/foundry_dev_tools/utils/api_types.py
@@ -72,7 +72,7 @@ SourceRid = str
 """A magritte source resource identifier."""
 
 ExtractRid = str
-"""A maggrite extract resource identifier."""
+"""A magritte extract resource identifier."""
 
 TableRid = str
 """A virtual table resource identifier."""

--- a/libs/foundry-dev-tools/src/foundry_dev_tools/utils/api_types.py
+++ b/libs/foundry-dev-tools/src/foundry_dev_tools/utils/api_types.py
@@ -71,6 +71,9 @@ ProjectRid = str
 SourceRid = str
 """A magritte source resource identifier."""
 
+ExtractRid = str
+"""A maggrite extract resource identifier."""
+
 TableRid = str
 """A virtual table resource identifier."""
 


### PR DESCRIPTION
# Summary
Adding one low-level api function `api_delete_extract` which takes one string value of the newly added `ExtractRid` type and deletes it pernamently.

Tested in my Palantir Foundry Environemnt, where it works.

The `Response` returned has code *204*, which translates to empty content.

# Checklist

- [X] You agree with our [CLA](https://gist.githubusercontent.com/emdgroup-admin/16cc45ea4315c2ef29eb9d9afc36fcf5/raw/abb9c91f15278a62b9ac3e66144bcd27fa9485c2/CLA.md)
- [X] Included tests (or is not applicable).
- [X] Updated [documentation](https://emdgroup.github.io/foundry-dev-tools/) (or is not applicable).
- [X] Used [pre-commit hooks](https://emdgroup.github.io/foundry-dev-tools/develop.html#pre-commit-hooks-formatting) to format and lint the code.
