### PR TITLE
Integrate public foundry sdk with fdt authentication

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog],
 and this project adheres to [Semantic Versioning].
 
+## [2.1.21] - 2025-10-28
+
+## Added
+- add official foundry-platform-sdk support under FoundryContext for public v2 APIs (#112)
+
 ## [2.1.20] - 2025-10-24
 
 ## Added

--- a/libs/foundry-dev-tools/pyproject.toml
+++ b/libs/foundry-dev-tools/pyproject.toml
@@ -47,7 +47,8 @@ git-credential-foundry = "foundry_dev_tools.cli.git_credential_foundry:_helper"
 
 [project.optional-dependencies]
 s3 = ["aiobotocore[boto3]"]
-full = ["foundry-dev-tools-transforms", "foundry-dev-tools[s3]"]
+public = ["foundry-platform-sdk"]
+full = ["foundry-dev-tools-transforms", "foundry-dev-tools[s3]", "foundry-dev-tools[public]"]
 
 [project.urls]
 Homepage = "https://emdgroup.github.io/foundry-dev-tools"

--- a/libs/foundry-dev-tools/src/foundry_dev_tools/_optional/foundry_platform_sdk.py
+++ b/libs/foundry-dev-tools/src/foundry_dev_tools/_optional/foundry_platform_sdk.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+try:
+    import foundry_sdk
+
+    foundry_sdk.__fake__ = False
+except ImportError:
+    from foundry_dev_tools._optional import FakeModule
+
+    foundry_sdk = FakeModule("foundry_sdk")
+
+__all__ = ["foundry_sdk"]

--- a/libs/foundry-dev-tools/src/foundry_dev_tools/_optional/foundry_platform_sdk.py
+++ b/libs/foundry-dev-tools/src/foundry_dev_tools/_optional/foundry_platform_sdk.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 try:
     import foundry_sdk
+    import foundry_sdk.v2
 
     foundry_sdk.__fake__ = False
 except ImportError:

--- a/libs/foundry-dev-tools/src/foundry_dev_tools/config/context.py
+++ b/libs/foundry-dev-tools/src/foundry_dev_tools/config/context.py
@@ -198,7 +198,7 @@ class FoundryContext:
 
         return FoundryClient(
             auth=FoundryDevToolsAuth(self),
-            hostname=self.host,
+            hostname=self.host.domain,
         )
 
     def get_dataset(

--- a/libs/foundry-dev-tools/src/foundry_dev_tools/config/context.py
+++ b/libs/foundry-dev-tools/src/foundry_dev_tools/config/context.py
@@ -196,6 +196,15 @@ class FoundryContext:
         """Returns :py:class:`foundry_sdk.v2.FoundryClient`.
 
         Uses fdt context to integrate with the official foundry-platform-sdk.
+
+        Examples:
+            >>> from foundry_dev_tools._optional.polars import pl
+            >>> from foundry_dev_tools._optional.pyarrow import pa
+
+            >>> pub_client = ctx.public_client_v2
+            >>> ds = pub_client.datasets.Dataset.read_table(rid, format="ARROW")
+            >>> pa_df = pa.ipc.open_stream(ds).read_all()
+            >>> polars_df = pl.from_arrow(pa_df)
         """
         from foundry_dev_tools.public_sdk.auth import FoundryDevToolsAuth
 

--- a/libs/foundry-dev-tools/src/foundry_dev_tools/config/context.py
+++ b/libs/foundry-dev-tools/src/foundry_dev_tools/config/context.py
@@ -33,18 +33,13 @@ from foundry_dev_tools.resources.resource import Resource
 from foundry_dev_tools.utils.config import entry_point_fdt_api_client
 
 if TYPE_CHECKING:
-    import foundry_sdk.v2
-    from foundry_sdk.v2 import FoundryClient
+    from foundry_sdk.v2 import FoundryClient as FoundrySdkV2Client
 
     from foundry_dev_tools.cached_foundry_client import CachedFoundryClient
     from foundry_dev_tools.config.config_types import Host, Token
     from foundry_dev_tools.config.token_provider import TokenProvider
     from foundry_dev_tools.foundry_api_client import FoundryRestClient
     from foundry_dev_tools.utils import api_types
-else:
-    from foundry_dev_tools._optional import foundry_platform_sdk
-
-    foundry_sdk = foundry_platform_sdk.foundry_sdk
 
 
 class FoundryContext:
@@ -192,7 +187,7 @@ class FoundryContext:
         return FoundryRestClient(ctx=self)
 
     @cached_property
-    def public_client_v2(self) -> FoundryClient:
+    def public_client_v2(self) -> FoundrySdkV2Client:
         """Returns :py:class:`foundry_sdk.v2.FoundryClient`.
 
         Uses fdt context to integrate with the official foundry-platform-sdk.
@@ -206,6 +201,7 @@ class FoundryContext:
             >>> pa_df = pa.ipc.open_stream(ds).read_all()
             >>> polars_df = pl.from_arrow(pa_df)
         """
+        from foundry_dev_tools._optional.foundry_platform_sdk import foundry_sdk
         from foundry_dev_tools.public_sdk.auth import FoundryDevToolsAuth
 
         return foundry_sdk.v2.FoundryClient(

--- a/libs/foundry-dev-tools/src/foundry_dev_tools/config/context.py
+++ b/libs/foundry-dev-tools/src/foundry_dev_tools/config/context.py
@@ -193,8 +193,8 @@ class FoundryContext:
         Uses fdt context to integrate with the official foundry-platform-sdk.
 
         Examples:
-            >>> from foundry_dev_tools._optional.polars import pl
-            >>> from foundry_dev_tools._optional.pyarrow import pa
+            >>> import polars as pl
+            >>> import pyarrow as pa
 
             >>> pub_client = ctx.public_client_v2
             >>> ds = pub_client.datasets.Dataset.read_table(rid, format="ARROW")

--- a/libs/foundry-dev-tools/src/foundry_dev_tools/config/context.py
+++ b/libs/foundry-dev-tools/src/foundry_dev_tools/config/context.py
@@ -33,6 +33,8 @@ from foundry_dev_tools.resources.resource import Resource
 from foundry_dev_tools.utils.config import entry_point_fdt_api_client
 
 if TYPE_CHECKING:
+    from foundry_sdk.v2 import FoundryClient
+
     from foundry_dev_tools.cached_foundry_client import CachedFoundryClient
     from foundry_dev_tools.config.config_types import Host, Token
     from foundry_dev_tools.config.token_provider import TokenProvider
@@ -183,6 +185,21 @@ class FoundryContext:
         from foundry_dev_tools.foundry_api_client import FoundryRestClient
 
         return FoundryRestClient(ctx=self)
+
+    @cached_property
+    def public_client_v2(self) -> FoundryClient:
+        """Returns :py:class:`foundry_sdk.v2.FoundryClient`.
+
+        Uses fdt context to integrate with the official foundry-platform-sdk.
+        """
+        from foundry_sdk.v2 import FoundryClient
+
+        from foundry_dev_tools.public_sdk.auth import FoundryDevToolsAuth
+
+        return FoundryClient(
+            auth=FoundryDevToolsAuth(self),
+            hostname=self.host,
+        )
 
     def get_dataset(
         self,

--- a/libs/foundry-dev-tools/src/foundry_dev_tools/config/context.py
+++ b/libs/foundry-dev-tools/src/foundry_dev_tools/config/context.py
@@ -33,6 +33,7 @@ from foundry_dev_tools.resources.resource import Resource
 from foundry_dev_tools.utils.config import entry_point_fdt_api_client
 
 if TYPE_CHECKING:
+    import foundry_sdk.v2
     from foundry_sdk.v2 import FoundryClient
 
     from foundry_dev_tools.cached_foundry_client import CachedFoundryClient
@@ -40,6 +41,10 @@ if TYPE_CHECKING:
     from foundry_dev_tools.config.token_provider import TokenProvider
     from foundry_dev_tools.foundry_api_client import FoundryRestClient
     from foundry_dev_tools.utils import api_types
+else:
+    from foundry_dev_tools._optional import foundry_platform_sdk
+
+    foundry_sdk = foundry_platform_sdk.foundry_sdk
 
 
 class FoundryContext:
@@ -192,11 +197,9 @@ class FoundryContext:
 
         Uses fdt context to integrate with the official foundry-platform-sdk.
         """
-        from foundry_sdk.v2 import FoundryClient
-
         from foundry_dev_tools.public_sdk.auth import FoundryDevToolsAuth
 
-        return FoundryClient(
+        return foundry_sdk.v2.FoundryClient(
             auth=FoundryDevToolsAuth(self),
             hostname=self.host.domain,
         )

--- a/libs/foundry-dev-tools/src/foundry_dev_tools/public_sdk/__init__.py
+++ b/libs/foundry-dev-tools/src/foundry_dev_tools/public_sdk/__init__.py
@@ -1,0 +1,10 @@
+"""Integration utilities for foundry-platform-sdk."""
+
+from __future__ import annotations
+
+from foundry_dev_tools.public_sdk.auth import FoundryDevToolsAuth, FoundryDevToolsToken
+
+__all__ = [
+    "FoundryDevToolsAuth",
+    "FoundryDevToolsToken",
+]

--- a/libs/foundry-dev-tools/src/foundry_dev_tools/public_sdk/auth.py
+++ b/libs/foundry-dev-tools/src/foundry_dev_tools/public_sdk/auth.py
@@ -1,0 +1,76 @@
+"""Auth adapters for integrating FoundryDevTools with foundry-platform-sdk."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, TypeVar
+
+from foundry_sdk import Auth
+from foundry_sdk._core.auth_utils import Token
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from foundry_dev_tools.config.context import FoundryContext
+
+
+T = TypeVar("T")
+
+
+class FoundryDevToolsToken(Token):
+    """Token adapter that implements the foundry_sdk Token interface."""
+
+    def __init__(self, token: str) -> None:
+        """Initialize the token wrapper.
+
+        Args:
+            token (str): The access token string
+        """
+        self._token = token
+
+    @property
+    def access_token(self) -> str:
+        """Return the access token.
+
+        Returns:
+            str: The access token
+        """
+        return self._token
+
+
+class FoundryDevToolsAuth(Auth):
+    """Auth adapter that bridges FoundryContext with foundry-platform-sdk."""
+
+    def __init__(self, ctx: FoundryContext) -> None:
+        """Initialize the auth adapter.
+
+        Args:
+            ctx: The FoundryContext instance to use for authentication
+        """
+        self._ctx: FoundryContext = ctx
+
+    def get_token(self) -> FoundryDevToolsToken:
+        """Get the current token from the FoundryContext.
+
+        Returns:
+            FoundryDevToolsToken: The wrapped access token
+        """
+        return FoundryDevToolsToken(self._ctx.token)
+
+    def execute_with_token(self, func: Callable[[FoundryDevToolsToken], T]) -> T:
+        """Execute a function with the current token.
+
+        Args:
+            func: Function to execute with the token
+
+        Returns:
+            T: The return value of the function
+        """
+        return func(self.get_token())
+
+    def run_with_token(self, func: Callable[[FoundryDevToolsToken], T]) -> None:
+        """Run a function with the current token without returning a value.
+
+        Args:
+            func: Function to run with the token
+        """
+        func(self.get_token())

--- a/libs/foundry-dev-tools/src/foundry_dev_tools/public_sdk/auth.py
+++ b/libs/foundry-dev-tools/src/foundry_dev_tools/public_sdk/auth.py
@@ -2,15 +2,28 @@
 
 from __future__ import annotations
 
+from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, TypeVar
-
-from foundry_sdk import Auth
-from foundry_sdk._core.auth_utils import Token
 
 if TYPE_CHECKING:
     from collections.abc import Callable
 
+    from foundry_sdk import Auth
+
     from foundry_dev_tools.config.context import FoundryContext
+else:
+    from foundry_dev_tools._optional.foundry_platform_sdk import foundry_sdk
+
+    Auth = foundry_sdk.Auth
+
+
+class Token(ABC):
+    """Reimplementation of the private foundry_sdk Token interface."""
+
+    @property
+    @abstractmethod
+    def access_token(self) -> str:  # noqa: D102
+        pass
 
 
 T = TypeVar("T")

--- a/libs/foundry-dev-tools/src/foundry_dev_tools/public_sdk/auth.py
+++ b/libs/foundry-dev-tools/src/foundry_dev_tools/public_sdk/auth.py
@@ -5,16 +5,12 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, TypeVar
 
+from foundry_dev_tools._optional.foundry_platform_sdk import foundry_sdk
+
 if TYPE_CHECKING:
     from collections.abc import Callable
 
-    from foundry_sdk import Auth
-
     from foundry_dev_tools.config.context import FoundryContext
-else:
-    from foundry_dev_tools._optional.foundry_platform_sdk import foundry_sdk
-
-    Auth = foundry_sdk.Auth
 
 
 class Token(ABC):
@@ -50,7 +46,7 @@ class FoundryDevToolsToken(Token):
         return self._token
 
 
-class FoundryDevToolsAuth(Auth):
+class FoundryDevToolsAuth(foundry_sdk.Auth):
     """Auth adapter that bridges FoundryContext with foundry-platform-sdk."""
 
     def __init__(self, ctx: FoundryContext) -> None:

--- a/pdm.lock
+++ b/pdm.lock
@@ -659,7 +659,7 @@ dependencies = [
 
 [[package]]
 name = "foundry-dev-tools"
-version = "2.1.9.dev1"
+version = "2.1.21.dev9"
 extras = ["public", "s3"]
 requires_python = ">=3.10"
 editable = true

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:20349f1a8b0fddd7dd1645ec1a66ac963c7379475b4eedc41c4bd0a205156474"
+content_hash = "sha256:e004ffe763162a2548e8e77260c4856842babeb675fdb3aec51e7b71ec5c09ea"
 
 [[metadata.targets]]
 requires_python = ">=3.10"
@@ -180,6 +180,20 @@ files = [
 ]
 
 [[package]]
+name = "annotated-types"
+version = "0.7.0"
+requires_python = ">=3.8"
+summary = "Reusable constraint types to use with typing.Annotated"
+groups = ["dev"]
+dependencies = [
+    "typing-extensions>=4.0.0; python_version < \"3.9\"",
+]
+files = [
+    {file = "annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53"},
+    {file = "annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89"},
+]
+
+[[package]]
 name = "ansicon"
 version = "1.89.0"
 summary = "Python wrapper for loading Jason Hood's ANSICON"
@@ -188,6 +202,23 @@ marker = "platform_system == \"Windows\""
 files = [
     {file = "ansicon-1.89.0-py2.py3-none-any.whl", hash = "sha256:f1def52d17f65c2c9682cf8370c03f541f410c1752d6a14029f97318e4b9dfec"},
     {file = "ansicon-1.89.0.tar.gz", hash = "sha256:e4d039def5768a47e4afec8e89e83ec3ae5a26bf00ad851f914d1240b444d2b1"},
+]
+
+[[package]]
+name = "anyio"
+version = "4.11.0"
+requires_python = ">=3.9"
+summary = "High-level concurrency and networking framework on top of asyncio or Trio"
+groups = ["dev"]
+dependencies = [
+    "exceptiongroup>=1.0.2; python_version < \"3.11\"",
+    "idna>=2.8",
+    "sniffio>=1.1",
+    "typing-extensions>=4.5; python_version < \"3.13\"",
+]
+files = [
+    {file = "anyio-4.11.0-py3-none-any.whl", hash = "sha256:0287e96f4d26d4149305414d4e3bc32f0dcd0862365a4bddea19d7a1ec38c4fc"},
+    {file = "anyio-4.11.0.tar.gz", hash = "sha256:82a8d0b81e318cc5ce71a5f1f8b5c4e63619620b63141ef8c995fa0db95a57c4"},
 ]
 
 [[package]]
@@ -628,8 +659,8 @@ dependencies = [
 
 [[package]]
 name = "foundry-dev-tools"
-version = "2.1.7"
-extras = ["s3"]
+version = "2.1.9.dev1"
+extras = ["public", "s3"]
 requires_python = ">=3.10"
 editable = true
 path = "./libs/foundry-dev-tools"
@@ -638,6 +669,26 @@ groups = ["dev"]
 dependencies = [
     "-e file:///${PROJECT_ROOT}/libs/foundry-dev-tools#egg=foundry-dev-tools",
     "aiobotocore[boto3]",
+    "foundry-platform-sdk",
+]
+
+[[package]]
+name = "foundry-platform-sdk"
+version = "1.62.0"
+requires_python = "<4.0,>=3.9"
+summary = "The official Python library for the Foundry API"
+groups = ["dev"]
+dependencies = [
+    "annotated-types<1.0.0,>=0.7.0",
+    "h11<1.0.0,>=0.16.0",
+    "httpx<1.0.0,>=0.25.0",
+    "pydantic<3.0.0,>=2.6.0",
+    "retrying<2.0.0,>=1.3.7",
+    "typing-extensions<5.0.0,>=4.7.1",
+]
+files = [
+    {file = "foundry_platform_sdk-1.62.0-py3-none-any.whl", hash = "sha256:221cf5afe3bf7543b7654dd552aa40ed866ba1402056f185a2f7f135266520b1"},
+    {file = "foundry_platform_sdk-1.62.0.tar.gz", hash = "sha256:995d2f267eb0a7d5622ebdff15c7c5892d8060c9ae53f581e8ced53a7264223d"},
 ]
 
 [[package]]
@@ -766,6 +817,49 @@ dependencies = [
 files = [
     {file = "GitPython-3.1.43-py3-none-any.whl", hash = "sha256:eec7ec56b92aad751f9912a73404bc02ba212a23adb2c7098ee668417051a1ff"},
     {file = "GitPython-3.1.43.tar.gz", hash = "sha256:35f314a9f878467f5453cc1fee295c3e18e52f1b99f10f6cf5b1682e968a9e7c"},
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+requires_python = ">=3.8"
+summary = "A pure-Python, bring-your-own-I/O implementation of HTTP/1.1"
+groups = ["dev"]
+files = [
+    {file = "h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86"},
+    {file = "h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1"},
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+requires_python = ">=3.8"
+summary = "A minimal low-level HTTP client."
+groups = ["dev"]
+dependencies = [
+    "certifi",
+    "h11>=0.16",
+]
+files = [
+    {file = "httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55"},
+    {file = "httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8"},
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+requires_python = ">=3.8"
+summary = "The next generation HTTP client."
+groups = ["dev"]
+dependencies = [
+    "anyio",
+    "certifi",
+    "httpcore==1.*",
+    "idna",
+]
+files = [
+    {file = "httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad"},
+    {file = "httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc"},
 ]
 
 [[package]]
@@ -1381,6 +1475,131 @@ files = [
 ]
 
 [[package]]
+name = "pydantic"
+version = "2.12.3"
+requires_python = ">=3.9"
+summary = "Data validation using Python type hints"
+groups = ["dev"]
+dependencies = [
+    "annotated-types>=0.6.0",
+    "pydantic-core==2.41.4",
+    "typing-extensions>=4.14.1",
+    "typing-inspection>=0.4.2",
+]
+files = [
+    {file = "pydantic-2.12.3-py3-none-any.whl", hash = "sha256:6986454a854bc3bc6e5443e1369e06a3a456af9d339eda45510f517d9ea5c6bf"},
+    {file = "pydantic-2.12.3.tar.gz", hash = "sha256:1da1c82b0fc140bb0103bc1441ffe062154c8d38491189751ee00fd8ca65ce74"},
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.41.4"
+requires_python = ">=3.9"
+summary = "Core functionality for Pydantic validation and serialization"
+groups = ["dev"]
+dependencies = [
+    "typing-extensions>=4.14.1",
+]
+files = [
+    {file = "pydantic_core-2.41.4-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:2442d9a4d38f3411f22eb9dd0912b7cbf4b7d5b6c92c4173b75d3e1ccd84e36e"},
+    {file = "pydantic_core-2.41.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:30a9876226dda131a741afeab2702e2d127209bde3c65a2b8133f428bc5d006b"},
+    {file = "pydantic_core-2.41.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d55bbac04711e2980645af68b97d445cdbcce70e5216de444a6c4b6943ebcccd"},
+    {file = "pydantic_core-2.41.4-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e1d778fb7849a42d0ee5927ab0f7453bf9f85eef8887a546ec87db5ddb178945"},
+    {file = "pydantic_core-2.41.4-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1b65077a4693a98b90ec5ad8f203ad65802a1b9b6d4a7e48066925a7e1606706"},
+    {file = "pydantic_core-2.41.4-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:62637c769dee16eddb7686bf421be48dfc2fae93832c25e25bc7242e698361ba"},
+    {file = "pydantic_core-2.41.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2dfe3aa529c8f501babf6e502936b9e8d4698502b2cfab41e17a028d91b1ac7b"},
+    {file = "pydantic_core-2.41.4-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ca2322da745bf2eeb581fc9ea3bbb31147702163ccbcbf12a3bb630e4bf05e1d"},
+    {file = "pydantic_core-2.41.4-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:e8cd3577c796be7231dcf80badcf2e0835a46665eaafd8ace124d886bab4d700"},
+    {file = "pydantic_core-2.41.4-cp310-cp310-musllinux_1_1_armv7l.whl", hash = "sha256:1cae8851e174c83633f0833e90636832857297900133705ee158cf79d40f03e6"},
+    {file = "pydantic_core-2.41.4-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:a26d950449aae348afe1ac8be5525a00ae4235309b729ad4d3399623125b43c9"},
+    {file = "pydantic_core-2.41.4-cp310-cp310-win32.whl", hash = "sha256:0cf2a1f599efe57fa0051312774280ee0f650e11152325e41dfd3018ef2c1b57"},
+    {file = "pydantic_core-2.41.4-cp310-cp310-win_amd64.whl", hash = "sha256:a8c2e340d7e454dc3340d3d2e8f23558ebe78c98aa8f68851b04dcb7bc37abdc"},
+    {file = "pydantic_core-2.41.4-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:28ff11666443a1a8cf2a044d6a545ebffa8382b5f7973f22c36109205e65dc80"},
+    {file = "pydantic_core-2.41.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:61760c3925d4633290292bad462e0f737b840508b4f722247d8729684f6539ae"},
+    {file = "pydantic_core-2.41.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:eae547b7315d055b0de2ec3965643b0ab82ad0106a7ffd29615ee9f266a02827"},
+    {file = "pydantic_core-2.41.4-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ef9ee5471edd58d1fcce1c80ffc8783a650e3e3a193fe90d52e43bb4d87bff1f"},
+    {file = "pydantic_core-2.41.4-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:15dd504af121caaf2c95cb90c0ebf71603c53de98305621b94da0f967e572def"},
+    {file = "pydantic_core-2.41.4-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3a926768ea49a8af4d36abd6a8968b8790f7f76dd7cbd5a4c180db2b4ac9a3a2"},
+    {file = "pydantic_core-2.41.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6916b9b7d134bff5440098a4deb80e4cb623e68974a87883299de9124126c2a8"},
+    {file = "pydantic_core-2.41.4-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5cf90535979089df02e6f17ffd076f07237efa55b7343d98760bde8743c4b265"},
+    {file = "pydantic_core-2.41.4-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:7533c76fa647fade2d7ec75ac5cc079ab3f34879626dae5689b27790a6cf5a5c"},
+    {file = "pydantic_core-2.41.4-cp311-cp311-musllinux_1_1_armv7l.whl", hash = "sha256:37e516bca9264cbf29612539801ca3cd5d1be465f940417b002905e6ed79d38a"},
+    {file = "pydantic_core-2.41.4-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:0c19cb355224037c83642429b8ce261ae108e1c5fbf5c028bac63c77b0f8646e"},
+    {file = "pydantic_core-2.41.4-cp311-cp311-win32.whl", hash = "sha256:09c2a60e55b357284b5f31f5ab275ba9f7f70b7525e18a132ec1f9160b4f1f03"},
+    {file = "pydantic_core-2.41.4-cp311-cp311-win_amd64.whl", hash = "sha256:711156b6afb5cb1cb7c14a2cc2c4a8b4c717b69046f13c6b332d8a0a8f41ca3e"},
+    {file = "pydantic_core-2.41.4-cp311-cp311-win_arm64.whl", hash = "sha256:6cb9cf7e761f4f8a8589a45e49ed3c0d92d1d696a45a6feaee8c904b26efc2db"},
+    {file = "pydantic_core-2.41.4-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:ab06d77e053d660a6faaf04894446df7b0a7e7aba70c2797465a0a1af00fc887"},
+    {file = "pydantic_core-2.41.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:c53ff33e603a9c1179a9364b0a24694f183717b2e0da2b5ad43c316c956901b2"},
+    {file = "pydantic_core-2.41.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:304c54176af2c143bd181d82e77c15c41cbacea8872a2225dd37e6544dce9999"},
+    {file = "pydantic_core-2.41.4-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:025ba34a4cf4fb32f917d5d188ab5e702223d3ba603be4d8aca2f82bede432a4"},
+    {file = "pydantic_core-2.41.4-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b9f5f30c402ed58f90c70e12eff65547d3ab74685ffe8283c719e6bead8ef53f"},
+    {file = "pydantic_core-2.41.4-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:dd96e5d15385d301733113bcaa324c8bcf111275b7675a9c6e88bfb19fc05e3b"},
+    {file = "pydantic_core-2.41.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:98f348cbb44fae6e9653c1055db7e29de67ea6a9ca03a5fa2c2e11a47cff0e47"},
+    {file = "pydantic_core-2.41.4-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ec22626a2d14620a83ca583c6f5a4080fa3155282718b6055c2ea48d3ef35970"},
+    {file = "pydantic_core-2.41.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:3a95d4590b1f1a43bf33ca6d647b990a88f4a3824a8c4572c708f0b45a5290ed"},
+    {file = "pydantic_core-2.41.4-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:f9672ab4d398e1b602feadcffcdd3af44d5f5e6ddc15bc7d15d376d47e8e19f8"},
+    {file = "pydantic_core-2.41.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:84d8854db5f55fead3b579f04bda9a36461dab0730c5d570e1526483e7bb8431"},
+    {file = "pydantic_core-2.41.4-cp312-cp312-win32.whl", hash = "sha256:9be1c01adb2ecc4e464392c36d17f97e9110fbbc906bcbe1c943b5b87a74aabd"},
+    {file = "pydantic_core-2.41.4-cp312-cp312-win_amd64.whl", hash = "sha256:d682cf1d22bab22a5be08539dca3d1593488a99998f9f412137bc323179067ff"},
+    {file = "pydantic_core-2.41.4-cp312-cp312-win_arm64.whl", hash = "sha256:833eebfd75a26d17470b58768c1834dfc90141b7afc6eb0429c21fc5a21dcfb8"},
+    {file = "pydantic_core-2.41.4-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:85e050ad9e5f6fe1004eec65c914332e52f429bc0ae12d6fa2092407a462c746"},
+    {file = "pydantic_core-2.41.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e7393f1d64792763a48924ba31d1e44c2cfbc05e3b1c2c9abb4ceeadd912cced"},
+    {file = "pydantic_core-2.41.4-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:94dab0940b0d1fb28bcab847adf887c66a27a40291eedf0b473be58761c9799a"},
+    {file = "pydantic_core-2.41.4-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:de7c42f897e689ee6f9e93c4bec72b99ae3b32a2ade1c7e4798e690ff5246e02"},
+    {file = "pydantic_core-2.41.4-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:664b3199193262277b8b3cd1e754fb07f2c6023289c815a1e1e8fb415cb247b1"},
+    {file = "pydantic_core-2.41.4-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d95b253b88f7d308b1c0b417c4624f44553ba4762816f94e6986819b9c273fb2"},
+    {file = "pydantic_core-2.41.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a1351f5bbdbbabc689727cb91649a00cb9ee7203e0a6e54e9f5ba9e22e384b84"},
+    {file = "pydantic_core-2.41.4-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1affa4798520b148d7182da0615d648e752de4ab1a9566b7471bc803d88a062d"},
+    {file = "pydantic_core-2.41.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:7b74e18052fea4aa8dea2fb7dbc23d15439695da6cbe6cfc1b694af1115df09d"},
+    {file = "pydantic_core-2.41.4-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:285b643d75c0e30abda9dc1077395624f314a37e3c09ca402d4015ef5979f1a2"},
+    {file = "pydantic_core-2.41.4-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:f52679ff4218d713b3b33f88c89ccbf3a5c2c12ba665fb80ccc4192b4608dbab"},
+    {file = "pydantic_core-2.41.4-cp313-cp313-win32.whl", hash = "sha256:ecde6dedd6fff127c273c76821bb754d793be1024bc33314a120f83a3c69460c"},
+    {file = "pydantic_core-2.41.4-cp313-cp313-win_amd64.whl", hash = "sha256:d081a1f3800f05409ed868ebb2d74ac39dd0c1ff6c035b5162356d76030736d4"},
+    {file = "pydantic_core-2.41.4-cp313-cp313-win_arm64.whl", hash = "sha256:f8e49c9c364a7edcbe2a310f12733aad95b022495ef2a8d653f645e5d20c1564"},
+    {file = "pydantic_core-2.41.4-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:ed97fd56a561f5eb5706cebe94f1ad7c13b84d98312a05546f2ad036bafe87f4"},
+    {file = "pydantic_core-2.41.4-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a870c307bf1ee91fc58a9a61338ff780d01bfae45922624816878dce784095d2"},
+    {file = "pydantic_core-2.41.4-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d25e97bc1f5f8f7985bdc2335ef9e73843bb561eb1fa6831fdfc295c1c2061cf"},
+    {file = "pydantic_core-2.41.4-cp313-cp313t-win_amd64.whl", hash = "sha256:d405d14bea042f166512add3091c1af40437c2e7f86988f3915fabd27b1e9cd2"},
+    {file = "pydantic_core-2.41.4-cp313-cp313t-win_arm64.whl", hash = "sha256:19f3684868309db5263a11bace3c45d93f6f24afa2ffe75a647583df22a2ff89"},
+    {file = "pydantic_core-2.41.4-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:e9205d97ed08a82ebb9a307e92914bb30e18cdf6f6b12ca4bedadb1588a0bfe1"},
+    {file = "pydantic_core-2.41.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:82df1f432b37d832709fbcc0e24394bba04a01b6ecf1ee87578145c19cde12ac"},
+    {file = "pydantic_core-2.41.4-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fc3b4cc4539e055cfa39a3763c939f9d409eb40e85813257dcd761985a108554"},
+    {file = "pydantic_core-2.41.4-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b1eb1754fce47c63d2ff57fdb88c351a6c0150995890088b33767a10218eaa4e"},
+    {file = "pydantic_core-2.41.4-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e6ab5ab30ef325b443f379ddb575a34969c333004fca5a1daa0133a6ffaad616"},
+    {file = "pydantic_core-2.41.4-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:31a41030b1d9ca497634092b46481b937ff9397a86f9f51bd41c4767b6fc04af"},
+    {file = "pydantic_core-2.41.4-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a44ac1738591472c3d020f61c6df1e4015180d6262ebd39bf2aeb52571b60f12"},
+    {file = "pydantic_core-2.41.4-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d72f2b5e6e82ab8f94ea7d0d42f83c487dc159c5240d8f83beae684472864e2d"},
+    {file = "pydantic_core-2.41.4-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:c4d1e854aaf044487d31143f541f7aafe7b482ae72a022c664b2de2e466ed0ad"},
+    {file = "pydantic_core-2.41.4-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:b568af94267729d76e6ee5ececda4e283d07bbb28e8148bb17adad93d025d25a"},
+    {file = "pydantic_core-2.41.4-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:6d55fb8b1e8929b341cc313a81a26e0d48aa3b519c1dbaadec3a6a2b4fcad025"},
+    {file = "pydantic_core-2.41.4-cp314-cp314-win32.whl", hash = "sha256:5b66584e549e2e32a1398df11da2e0a7eff45d5c2d9db9d5667c5e6ac764d77e"},
+    {file = "pydantic_core-2.41.4-cp314-cp314-win_amd64.whl", hash = "sha256:557a0aab88664cc552285316809cab897716a372afaf8efdbef756f8b890e894"},
+    {file = "pydantic_core-2.41.4-cp314-cp314-win_arm64.whl", hash = "sha256:3f1ea6f48a045745d0d9f325989d8abd3f1eaf47dd00485912d1a3a63c623a8d"},
+    {file = "pydantic_core-2.41.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:6c1fe4c5404c448b13188dd8bd2ebc2bdd7e6727fa61ff481bcc2cca894018da"},
+    {file = "pydantic_core-2.41.4-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:523e7da4d43b113bf8e7b49fa4ec0c35bf4fe66b2230bfc5c13cc498f12c6c3e"},
+    {file = "pydantic_core-2.41.4-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5729225de81fb65b70fdb1907fcf08c75d498f4a6f15af005aabb1fdadc19dfa"},
+    {file = "pydantic_core-2.41.4-cp314-cp314t-win_amd64.whl", hash = "sha256:de2cfbb09e88f0f795fd90cf955858fc2c691df65b1f21f0aa00b99f3fbc661d"},
+    {file = "pydantic_core-2.41.4-cp314-cp314t-win_arm64.whl", hash = "sha256:d34f950ae05a83e0ede899c595f312ca976023ea1db100cd5aa188f7005e3ab0"},
+    {file = "pydantic_core-2.41.4-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:1e5ab4fc177dd41536b3c32b2ea11380dd3d4619a385860621478ac2d25ceb00"},
+    {file = "pydantic_core-2.41.4-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:3d88d0054d3fa11ce936184896bed3c1c5441d6fa483b498fac6a5d0dd6f64a9"},
+    {file = "pydantic_core-2.41.4-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7b2a054a8725f05b4b6503357e0ac1c4e8234ad3b0c2ac130d6ffc66f0e170e2"},
+    {file = "pydantic_core-2.41.4-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:b0d9db5a161c99375a0c68c058e227bee1d89303300802601d76a3d01f74e258"},
+    {file = "pydantic_core-2.41.4-pp310-pypy310_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:6273ea2c8ffdac7b7fda2653c49682db815aebf4a89243a6feccf5e36c18c347"},
+    {file = "pydantic_core-2.41.4-pp310-pypy310_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:4c973add636efc61de22530b2ef83a65f39b6d6f656df97f678720e20de26caa"},
+    {file = "pydantic_core-2.41.4-pp310-pypy310_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:b69d1973354758007f46cf2d44a4f3d0933f10b6dc9bf15cf1356e037f6f731a"},
+    {file = "pydantic_core-2.41.4-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:3619320641fd212aaf5997b6ca505e97540b7e16418f4a241f44cdf108ffb50d"},
+    {file = "pydantic_core-2.41.4-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:491535d45cd7ad7e4a2af4a5169b0d07bebf1adfd164b0368da8aa41e19907a5"},
+    {file = "pydantic_core-2.41.4-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:54d86c0cada6aba4ec4c047d0e348cbad7063b87ae0f005d9f8c9ad04d4a92a2"},
+    {file = "pydantic_core-2.41.4-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eca1124aced216b2500dc2609eade086d718e8249cb9696660ab447d50a758bd"},
+    {file = "pydantic_core-2.41.4-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:6c9024169becccf0cb470ada03ee578d7348c119a0d42af3dcf9eda96e3a247c"},
+    {file = "pydantic_core-2.41.4-pp311-pypy311_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:26895a4268ae5a2849269f4991cdc97236e4b9c010e51137becf25182daac405"},
+    {file = "pydantic_core-2.41.4-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:ca4df25762cf71308c446e33c9b1fdca2923a3f13de616e2a949f38bf21ff5a8"},
+    {file = "pydantic_core-2.41.4-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:5a28fcedd762349519276c36634e71853b4541079cab4acaaac60c4421827308"},
+    {file = "pydantic_core-2.41.4-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:c173ddcd86afd2535e2b695217e82191580663a1d1928239f877f5a1649ef39f"},
+    {file = "pydantic_core-2.41.4.tar.gz", hash = "sha256:70e47929a9d4a1905a67e4b687d5946026390568a8e952b92824118063cee4d5"},
+]
+
+[[package]]
 name = "pydeck"
 version = "0.9.1"
 requires_python = ">=3.8"
@@ -1620,6 +1839,17 @@ files = [
 ]
 
 [[package]]
+name = "retrying"
+version = "1.4.2"
+requires_python = ">=3.6"
+summary = "Retrying"
+groups = ["dev"]
+files = [
+    {file = "retrying-1.4.2-py3-none-any.whl", hash = "sha256:bbc004aeb542a74f3569aeddf42a2516efefcdaff90df0eb38fbfbf19f179f59"},
+    {file = "retrying-1.4.2.tar.gz", hash = "sha256:d102e75d53d8d30b88562d45361d6c6c934da06fab31bd81c0420acb97a8ba39"},
+]
+
+[[package]]
 name = "rich"
 version = "13.8.1"
 requires_python = ">=3.7.0"
@@ -1798,6 +2028,17 @@ files = [
 ]
 
 [[package]]
+name = "sniffio"
+version = "1.3.1"
+requires_python = ">=3.7"
+summary = "Sniff out which async library your code is running under"
+groups = ["dev"]
+files = [
+    {file = "sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2"},
+    {file = "sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc"},
+]
+
+[[package]]
 name = "streamlit"
 version = "1.38.0"
 requires_python = "!=3.9.7,>=3.8"
@@ -1907,13 +2148,27 @@ files = [
 
 [[package]]
 name = "typing-extensions"
-version = "4.12.2"
-requires_python = ">=3.8"
-summary = "Backported and Experimental Type Hints for Python 3.8+"
+version = "4.15.0"
+requires_python = ">=3.9"
+summary = "Backported and Experimental Type Hints for Python 3.9+"
 groups = ["dev"]
 files = [
-    {file = "typing_extensions-4.12.2-py3-none-any.whl", hash = "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d"},
-    {file = "typing_extensions-4.12.2.tar.gz", hash = "sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8"},
+    {file = "typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548"},
+    {file = "typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466"},
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.2"
+requires_python = ">=3.9"
+summary = "Runtime typing introspection tools"
+groups = ["dev"]
+dependencies = [
+    "typing-extensions>=4.12.0",
+]
+files = [
+    {file = "typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7"},
+    {file = "typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ distribution = false
 [tool.pdm.dev-dependencies]
 dev = [
   "-e file:///${PROJECT_ROOT}/libs/transforms",
-  "-e file:///${PROJECT_ROOT}/libs/foundry-dev-tools[s3]",
+  "-e file:///${PROJECT_ROOT}/libs/foundry-dev-tools[s3,public]",
   "pre-commit",
   "ruff",
   "pytest",

--- a/tests/unit/public_sdk/__init__.py
+++ b/tests/unit/public_sdk/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for public_sdk module."""

--- a/tests/unit/public_sdk/test_auth.py
+++ b/tests/unit/public_sdk/test_auth.py
@@ -2,9 +2,6 @@
 
 from __future__ import annotations
 
-import pytest
-
-from foundry_dev_tools._optional import FakeModule
 from foundry_dev_tools.public_sdk.auth import FoundryDevToolsAuth, FoundryDevToolsToken
 
 
@@ -38,20 +35,3 @@ def test_public_client_v2_uses_foundry_dev_tools_auth(test_context_mock):
     assert isinstance(client, FoundryClient)
 
     assert test_context_mock.host.domain is not None
-
-
-def test_public_client_v2_raises_helpful_error_when_sdk_not_installed(test_context_mock):
-    """Verify helpful error message when foundry-platform-sdk is not installed."""
-    import foundry_dev_tools.config.context as context_module
-
-    orig_foundry_sdk = context_module.foundry_sdk
-    context_module.foundry_sdk = FakeModule("foundry-platform-sdk")
-
-    try:
-        if "public_client_v2" in test_context_mock.__dict__:
-            del test_context_mock.__dict__["public_client_v2"]
-
-        with pytest.raises(ImportError, match="Missing optional dependency 'foundry-platform-sdk'"):
-            _ = test_context_mock.public_client_v2
-    finally:
-        context_module.foundry_sdk = orig_foundry_sdk

--- a/tests/unit/public_sdk/test_auth.py
+++ b/tests/unit/public_sdk/test_auth.py
@@ -1,0 +1,37 @@
+"""Tests for foundry-platform-sdk auth integration."""
+
+from __future__ import annotations
+
+from foundry_dev_tools.public_sdk.auth import FoundryDevToolsAuth, FoundryDevToolsToken
+
+
+def test_foundry_dev_tools_token_access_token():
+    """Verify FoundryDevToolsToken.access_token returns the correct token."""
+    test_token = "my-test-token-123"  # noqa: S105
+
+    token = FoundryDevToolsToken(test_token)
+
+    assert token.access_token == test_token
+
+
+def test_foundry_dev_tools_auth_get_token_bridges_context_token(test_context_mock):
+    """Verify FoundryDevToolsAuth.get_token() retrieves token from FoundryContext."""
+    expected_token = "context-token-456"  # noqa: S105
+    test_context_mock.token_provider._jwt = expected_token
+
+    auth = FoundryDevToolsAuth(test_context_mock)
+    token = auth.get_token()
+
+    assert isinstance(token, FoundryDevToolsToken)
+    assert token.access_token == expected_token
+
+
+def test_public_client_v2_uses_foundry_dev_tools_auth(test_context_mock):
+    """Verify FoundryContext.public_client_v2 creates FoundryClient with FoundryDevToolsAuth."""
+    from foundry_sdk.v2 import FoundryClient
+
+    client = test_context_mock.public_client_v2
+
+    assert isinstance(client, FoundryClient)
+
+    assert test_context_mock.host.domain is not None

--- a/tests/unit/public_sdk/test_auth.py
+++ b/tests/unit/public_sdk/test_auth.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import pytest
+
+from foundry_dev_tools._optional import FakeModule
 from foundry_dev_tools.public_sdk.auth import FoundryDevToolsAuth, FoundryDevToolsToken
 
 
@@ -35,3 +38,20 @@ def test_public_client_v2_uses_foundry_dev_tools_auth(test_context_mock):
     assert isinstance(client, FoundryClient)
 
     assert test_context_mock.host.domain is not None
+
+
+def test_public_client_v2_raises_helpful_error_when_sdk_not_installed(test_context_mock):
+    """Verify helpful error message when foundry-platform-sdk is not installed."""
+    import foundry_dev_tools.config.context as context_module
+
+    orig_foundry_sdk = context_module.foundry_sdk
+    context_module.foundry_sdk = FakeModule("foundry-platform-sdk")
+
+    try:
+        if "public_client_v2" in test_context_mock.__dict__:
+            del test_context_mock.__dict__["public_client_v2"]
+
+        with pytest.raises(ImportError, match="Missing optional dependency 'foundry-platform-sdk'"):
+            _ = test_context_mock.public_client_v2
+    finally:
+        context_module.foundry_sdk = orig_foundry_sdk


### PR DESCRIPTION
# Summary

Extend the FoundryContext with a cached client `public_client_v2` for using the public V2 APIs for dataset interaction. This enables foundry dev tools to read datasets even with user access tokens coming from OSDK enabled TPAs.

# Checklist

- [x] You agree with our [CLA](https://gist.githubusercontent.com/emdgroup-admin/16cc45ea4315c2ef29eb9d9afc36fcf5/raw/abb9c91f15278a62b9ac3e66144bcd27fa9485c2/CLA.md)
- [x] Included tests (or is not applicable).
- [x] Updated [documentation](https://emdgroup.github.io/foundry-dev-tools/) (or is not applicable).
- [x] Used [pre-commit hooks](https://emdgroup.github.io/foundry-dev-tools/develop.html#pre-commit-hooks-formatting) to format and lint the code.
