### PR TITLE
Adding `DataHealthClient` & changelog update [2.1.22]

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -375,6 +375,7 @@ and this project adheres to [Semantic Versioning].
 [Keep a Changelog]: https://keepachangelog.com/en/1.0.0/
 [Semantic Versioning]: https://semver.org/spec/v2.0.0.html
 
+[2.1.22]: https://github.com/emdgroup/foundry-dev-tools/compare/v2.1.21...v2.1.22
 [2.1.21]: https://github.com/emdgroup/foundry-dev-tools/compare/v2.1.20...v2.1.21
 [2.1.20]: https://github.com/emdgroup/foundry-dev-tools/compare/v2.1.19...v2.1.20
 [2.1.19]: https://github.com/emdgroup/foundry-dev-tools/compare/v2.1.18...v2.1.19

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog],
 and this project adheres to [Semantic Versioning].
 
+## [2.1.22] - 2025-12-15
+
+## Added
+- add DataHealthClient with two functions for obtaining Foundry Checks and Check Runs (#114)
+
 ## [2.1.21] - 2025-10-28
 
 ## Added
@@ -370,6 +375,7 @@ and this project adheres to [Semantic Versioning].
 [Keep a Changelog]: https://keepachangelog.com/en/1.0.0/
 [Semantic Versioning]: https://semver.org/spec/v2.0.0.html
 
+[2.1.21]: https://github.com/emdgroup/foundry-dev-tools/compare/v2.1.20...v2.1.21
 [2.1.20]: https://github.com/emdgroup/foundry-dev-tools/compare/v2.1.19...v2.1.20
 [2.1.19]: https://github.com/emdgroup/foundry-dev-tools/compare/v2.1.18...v2.1.19
 [2.1.18]: https://github.com/emdgroup/foundry-dev-tools/compare/v2.1.17...v2.1.18

--- a/libs/foundry-dev-tools/src/foundry_dev_tools/clients/data_health.py
+++ b/libs/foundry-dev-tools/src/foundry_dev_tools/clients/data_health.py
@@ -2,14 +2,17 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, List
+from typing import TYPE_CHECKING
 
-from foundry_dev_tools.clients.api_client import PublicAPIClient, APIClient
+from foundry_dev_tools.clients.api_client import APIClient
 
 if TYPE_CHECKING:
     import requests
 
-    from foundry_dev_tools.utils import api_types
+    from foundry_dev_tools.utils.api_types import (
+        CheckRid,
+        DatasetRid,
+    )
 
 
 class DataHealthClient(APIClient):
@@ -19,7 +22,7 @@ class DataHealthClient(APIClient):
 
     def api_get_checks_for_dataset(
         self,
-        datasetRid: datasetRid,
+        dataset_rid: DatasetRid,
         branch: str = "master",
         **kwargs,
     ) -> requests.Response:
@@ -32,29 +35,25 @@ class DataHealthClient(APIClient):
         """
         return self.api_request(
             "GET",
-            api_path=f"checks/v2/{datasetRid}/{branch}",
+            api_path=f"checks/v2/{dataset_rid}/{branch}",
             **kwargs,
         )
-    
+
     def api_get_latest_checks_history(
-        self,
-        checkRids: List[CheckRid] | CheckRid,
-        limit: int | None = None,
-        **kwargs
+        self, check_rids: list[CheckRid] | CheckRid, limit: int | None = None, **kwargs
     ) -> requests.Response:
-        """Returns complete CheckRun metadata for the last `limit` number of check runs
-        for the given list of Check RIDs.
+        """Returns CheckRun metadata for the last `limit` number of check runs for the given list of Check RIDs.
 
         Args:
-            checkRids: a list of CheckRIDs or a single string value.
+            check_rids: a list of CheckRIDs or a single string value.
             limit: number of last check runs to go for for each Check RID. Defaults to 5.
             **kwargs: gets passed to :py:meth:`APIClient.api_request`
         """
-        checkRids = checkRids if isinstance(checkRids, list) else [checkRids]
+        check_rids = check_rids if isinstance(check_rids, list) else [check_rids]
         limit = limit if limit else 5
         return self.api_request(
             "POST",
             api_path=f"checks/reports/v2/latest?limit={limit}",
-            json=checkRids,
+            json=check_rids,
             **kwargs,
         )

--- a/libs/foundry-dev-tools/src/foundry_dev_tools/clients/data_health.py
+++ b/libs/foundry-dev-tools/src/foundry_dev_tools/clients/data_health.py
@@ -40,7 +40,7 @@ class DataHealthClient(APIClient):
         )
 
     def api_get_latest_checks_history(
-        self, check_rids: list[CheckRid] | CheckRid, limit: int | None = None, **kwargs
+        self, check_rids: list[CheckRid] | CheckRid, limit: int = 5, **kwargs
     ) -> requests.Response:
         """Returns CheckRun metadata for the last `limit` number of check runs for the given list of Check RIDs.
 
@@ -50,10 +50,11 @@ class DataHealthClient(APIClient):
             **kwargs: gets passed to :py:meth:`APIClient.api_request`
         """
         check_rids = check_rids if isinstance(check_rids, list) else [check_rids]
-        limit = limit if limit else 5
+        params = {"limit": limit}
         return self.api_request(
             "POST",
-            api_path=f"checks/reports/v2/latest?limit={limit}",
+            api_path="checks/reports/v2/latest",
             json=check_rids,
+            params=params,
             **kwargs,
         )

--- a/libs/foundry-dev-tools/src/foundry_dev_tools/clients/data_health.py
+++ b/libs/foundry-dev-tools/src/foundry_dev_tools/clients/data_health.py
@@ -1,0 +1,60 @@
+"""Implementation of the data-health API."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, List
+
+from foundry_dev_tools.clients.api_client import PublicAPIClient, APIClient
+
+if TYPE_CHECKING:
+    import requests
+
+    from foundry_dev_tools.utils import api_types
+
+
+class DataHealthClient(APIClient):
+    """DataHealthClient class that implements methods from the 'foundry-data-health' API."""
+
+    api_name = "data-health"
+
+    def api_get_checks_for_dataset(
+        self,
+        datasetRid: datasetRid,
+        branch: str = "master",
+        **kwargs,
+    ) -> requests.Response:
+        """Gets all the Check RIDs available for the given Dataset RID and branch name.
+
+        Args:
+            dataset_rid: The RID of the dataset
+            branch: The name of the branch
+            **kwargs: gets passed to :py:meth:`APIClient.api_request`
+        """
+        return self.api_request(
+            "GET",
+            api_path=f"checks/v2/{datasetRid}/{branch}",
+            **kwargs,
+        )
+    
+    def api_get_latest_checks_history(
+        self,
+        checkRids: List[CheckRid] | CheckRid,
+        limit: int | None = None,
+        **kwargs
+    ) -> requests.Response:
+        """Returns complete CheckRun metadata for the last `limit` number of check runs
+        for the given list of Check RIDs.
+
+        Args:
+            checkRids: a list of CheckRIDs or a single string value.
+            limit: number of last check runs to go for for each Check RID. Defaults to 5.
+            **kwargs: gets passed to :py:meth:`APIClient.api_request`
+        """
+        checkRids = checkRids if isinstance(checkRids, list) else [checkRids]
+        limit = limit if limit else 5
+        return self.api_request(
+            "POST",
+            api_path=f"checks/reports/v2/latest?limit={limit}",
+            json=checkRids,
+            **kwargs,
+        )

--- a/libs/foundry-dev-tools/src/foundry_dev_tools/config/context.py
+++ b/libs/foundry-dev-tools/src/foundry_dev_tools/config/context.py
@@ -13,6 +13,7 @@ from foundry_dev_tools.clients import (
     catalog,
     compass,
     context_client,
+    data_health,
     data_proxy,
     foundry_sql_server,
     foundry_stats,
@@ -125,6 +126,11 @@ class FoundryContext:
     def metadata(self) -> metadata.MetadataClient:
         """Returns :py:class:`foundry_dev_tools.clients.metadata.MetadataClient`."""
         return metadata.MetadataClient(self)
+
+    @cached_property
+    def data_health(self) -> data_health.DataHealthClient:
+        """Returns :py:class:`foundry_dev_tools.clients.data_health.DataHealthClient`."""
+        return data_health.DataHealthClient(self)
 
     @cached_property
     def data_proxy(self) -> data_proxy.DataProxyClient:

--- a/libs/foundry-dev-tools/src/foundry_dev_tools/utils/api_types.py
+++ b/libs/foundry-dev-tools/src/foundry_dev_tools/utils/api_types.py
@@ -60,7 +60,7 @@ FolderRid = str
 """A compass folder resource identifier."""
 
 CheckRid = str
-"""A foundry data check resource identifier"""
+"""A foundry data check resource identifier."""
 
 JobSpecRid = str
 """A jobspec resource identifier."""

--- a/libs/foundry-dev-tools/src/foundry_dev_tools/utils/api_types.py
+++ b/libs/foundry-dev-tools/src/foundry_dev_tools/utils/api_types.py
@@ -59,6 +59,9 @@ RoleId = str
 FolderRid = str
 """A compass folder resource identifier."""
 
+CheckRid = str
+"""A foundry data check resource identifier"""
+
 JobSpecRid = str
 """A jobspec resource identifier."""
 


### PR DESCRIPTION
# Summary

Implementing new API client with 2 internal endpoints already implemented:
- `data-health/api/checks/v2/{datasetRid}/{branch}` - for obtaining a complete list of all the available `CheckRid`s for a given dataset RID.
- `data-health/api/checks/reports/v2/latest?limit={limit}` - for obtaining all the `CheckRunRid`s for a given `List[CheckRid]` or a single string `CheckRid` value.

Prepared for the next release (a new changelog.md entry)

# Checklist

- [x] You agree with our [CLA](https://gist.githubusercontent.com/emdgroup-admin/16cc45ea4315c2ef29eb9d9afc36fcf5/raw/abb9c91f15278a62b9ac3e66144bcd27fa9485c2/CLA.md)
- [x] Included tests (or is not applicable).
- [x] Updated [documentation](https://emdgroup.github.io/foundry-dev-tools/) (or is not applicable).
- [x] Used [pre-commit hooks](https://emdgroup.github.io/foundry-dev-tools/develop.html#pre-commit-hooks-formatting) to format and lint the code.
