### PR TITLE
Implement query_foundry_sql(return_type='polars')

### DIFF
--- a/docs/dev/contribute.md
+++ b/docs/dev/contribute.md
@@ -22,9 +22,9 @@ First create an environment specifically for foundry-dev-tools with pdm and acti
 mamba create -n foundry-dev-tools python=3.12 pdm openjdk=17
 mamba activate foundry-dev-tools
 ```
+````
 Note that python>3.12 throws an error when running `pdm install`: `configured Python interpreter version (3.14) is newer than PyO3's maximum supported version (3.12)`.
 
-````
 ````{tab} Without Conda/Mamba
 If you don't want to use conda or mamba, you'll need to install pdm through other means.
 It is available in most Linux package managers, Homebrew, Scoop and also via pip.

--- a/docs/dev/contribute.md
+++ b/docs/dev/contribute.md
@@ -19,9 +19,11 @@ cd foundry-dev-tools
 ````{tab} Conda/Mamba
 First create an environment specifically for foundry-dev-tools with pdm and activate it
 ```shell
-mamba create -n foundry-dev-tools pdm openjdk===17
+mamba create -n foundry-dev-tools python=3.12 pdm openjdk=17
 mamba activate foundry-dev-tools
 ```
+Note that python>3.12 throws an error when running `pdm install`: `configured Python interpreter version (3.14) is newer than PyO3's maximum supported version (3.12)`.
+
 ````
 ````{tab} Without Conda/Mamba
 If you don't want to use conda or mamba, you'll need to install pdm through other means.

--- a/docs/examples/dataset.md
+++ b/docs/examples/dataset.md
@@ -260,9 +260,7 @@ import polars as pl
 
 ctx = FoundryContext()
 ds = ctx.get_dataset_by_path("/path/to/test_dataset")
-arrow_table = ds.query_foundry_sql("SELECT *",return_type="arrow")
-
-df = pl.from_arrow(arrow_table)
+df = ds.query_foundry_sql("SELECT *", return_type="polars")
 print(df)
 ```
 ````

--- a/libs/foundry-dev-tools/src/foundry_dev_tools/clients/data_proxy.py
+++ b/libs/foundry-dev-tools/src/foundry_dev_tools/clients/data_proxy.py
@@ -111,7 +111,7 @@ class DataProxyClient(APIClient):
         branch: Ref = ...,
         sql_dialect: SqlDialect = ...,
         timeout: int = ...,
-    ) -> pd.DataFrame: ...
+    ) -> pd.core.frame.DataFrame: ...
 
     @overload
     def query_foundry_sql_legacy(
@@ -151,7 +151,7 @@ class DataProxyClient(APIClient):
         branch: Ref = ...,
         sql_dialect: SqlDialect = ...,
         timeout: int = ...,
-    ) -> tuple[dict, list[list]] | pd.DataFrame | pa.Table | pyspark.sql.DataFrame: ...
+    ) -> tuple[dict, list[list]] | pd.core.frame.DataFrame | pa.Table | pyspark.sql.DataFrame: ...
 
     def query_foundry_sql_legacy(
         self,
@@ -160,7 +160,7 @@ class DataProxyClient(APIClient):
         branch: Ref = "master",
         sql_dialect: SqlDialect = "SPARK",
         timeout: int = 600,
-    ) -> tuple[dict, list[list]] | pd.DataFrame | pa.Table | pyspark.sql.DataFrame:
+    ) -> tuple[dict, list[list]] | pd.core.frame.DataFrame | pa.Table | pyspark.sql.DataFrame:
         """Queries the dataproxy query API with spark SQL.
 
         Example:
@@ -220,7 +220,6 @@ class DataProxyClient(APIClient):
                 data=response_json["rows"],
                 names=[e["name"] for e in response_json["foundrySchema"]["fieldSchemaList"]],
             )
-
         if return_type == "spark":
             from foundry_dev_tools.utils.converter.foundry_spark import (
                 foundry_schema_to_spark_schema,

--- a/libs/foundry-dev-tools/src/foundry_dev_tools/clients/data_proxy.py
+++ b/libs/foundry-dev-tools/src/foundry_dev_tools/clients/data_proxy.py
@@ -27,6 +27,7 @@ if TYPE_CHECKING:
     from pathlib import Path
 
     import pandas as pd
+    import polars as pl
     import pyarrow as pa
     import pyspark
     import requests
@@ -111,7 +112,17 @@ class DataProxyClient(APIClient):
         branch: Ref = ...,
         sql_dialect: SqlDialect = ...,
         timeout: int = ...,
-    ) -> pd.core.frame.DataFrame: ...
+    ) -> pd.DataFrame: ...
+
+    @overload
+    def query_foundry_sql_legacy(
+        self,
+        query: str,
+        return_type: Literal["polars"],
+        branch: Ref = ...,
+        sql_dialect: SqlDialect = ...,
+        timeout: int = ...,
+    ) -> pl.DataFrame: ...
 
     @overload
     def query_foundry_sql_legacy(
@@ -151,7 +162,7 @@ class DataProxyClient(APIClient):
         branch: Ref = ...,
         sql_dialect: SqlDialect = ...,
         timeout: int = ...,
-    ) -> tuple[dict, list[list]] | pd.core.frame.DataFrame | pa.Table | pyspark.sql.DataFrame: ...
+    ) -> tuple[dict, list[list]] | pd.DataFrame | pl.DataFrame | pa.Table | pyspark.sql.DataFrame: ...
 
     def query_foundry_sql_legacy(
         self,
@@ -160,7 +171,7 @@ class DataProxyClient(APIClient):
         branch: Ref = "master",
         sql_dialect: SqlDialect = "SPARK",
         timeout: int = 600,
-    ) -> tuple[dict, list[list]] | pd.core.frame.DataFrame | pa.Table | pyspark.sql.DataFrame:
+    ) -> tuple[dict, list[list]] | pd.DataFrame | pl.DataFrame | pa.Table | pyspark.sql.DataFrame:
         """Queries the dataproxy query API with spark SQL.
 
         Example:
@@ -206,6 +217,9 @@ class DataProxyClient(APIClient):
         response_json = response.json()
         if return_type == "raw":
             return response_json["foundrySchema"], response_json["rows"]
+        # return_type arrows, pandas and polars use the FakeModule implementation in
+        # their _optional packages. The FakeModule throws an ImportError when trying
+        # to access attributes of the module, so no need to explicitly catch ImportError.
         if return_type == "pandas":
             from foundry_dev_tools._optional.pandas import pd
 
@@ -213,13 +227,19 @@ class DataProxyClient(APIClient):
                 data=response_json["rows"],
                 columns=[e["name"] for e in response_json["foundrySchema"]["fieldSchemaList"]],
             )
-        if return_type == "arrow":
+        if return_type in {"arrow", "polars"}:
             from foundry_dev_tools._optional.pyarrow import pa
 
-            return pa.table(
+            table = pa.table(
                 data=response_json["rows"],
                 names=[e["name"] for e in response_json["foundrySchema"]["fieldSchemaList"]],
             )
+            if return_type == "arrow":
+                return table
+
+            from foundry_dev_tools._optional.polars import pl
+
+            return pl.from_arrow(table)
         if return_type == "spark":
             from foundry_dev_tools.utils.converter.foundry_spark import (
                 foundry_schema_to_spark_schema,

--- a/libs/foundry-dev-tools/src/foundry_dev_tools/clients/data_proxy.py
+++ b/libs/foundry-dev-tools/src/foundry_dev_tools/clients/data_proxy.py
@@ -27,7 +27,6 @@ if TYPE_CHECKING:
     from pathlib import Path
 
     import pandas as pd
-    import polars as pl
     import pyarrow as pa
     import pyspark
     import requests
@@ -138,16 +137,6 @@ class DataProxyClient(APIClient):
     def query_foundry_sql_legacy(
         self,
         query: str,
-        return_type: Literal["polars"],
-        branch: Ref = ...,
-        sql_dialect: SqlDialect = ...,
-        timeout: int = ...,
-    ) -> pl.DataFrame: ...
-
-    @overload
-    def query_foundry_sql_legacy(
-        self,
-        query: str,
         return_type: Literal["raw"],
         branch: Ref = ...,
         sql_dialect: SqlDialect = ...,
@@ -162,7 +151,7 @@ class DataProxyClient(APIClient):
         branch: Ref = ...,
         sql_dialect: SqlDialect = ...,
         timeout: int = ...,
-    ) -> tuple[dict, list[list]] | pd.DataFrame | pl.DataFrame | pa.Table | pyspark.sql.DataFrame: ...
+    ) -> tuple[dict, list[list]] | pd.DataFrame | pa.Table | pyspark.sql.DataFrame: ...
 
     def query_foundry_sql_legacy(
         self,
@@ -171,7 +160,7 @@ class DataProxyClient(APIClient):
         branch: Ref = "master",
         sql_dialect: SqlDialect = "SPARK",
         timeout: int = 600,
-    ) -> tuple[dict, list[list]] | pd.DataFrame | pl.DataFrame | pa.Table | pyspark.sql.DataFrame:
+    ) -> tuple[dict, list[list]] | pd.DataFrame | pa.Table | pyspark.sql.DataFrame:
         """Queries the dataproxy query API with spark SQL.
 
         Example:
@@ -224,23 +213,14 @@ class DataProxyClient(APIClient):
                 data=response_json["rows"],
                 columns=[e["name"] for e in response_json["foundrySchema"]["fieldSchemaList"]],
             )
-        if return_type in {"arrow", "polars"}:
+        if return_type == "arrow":
             from foundry_dev_tools._optional.pyarrow import pa
 
-            arrow_table = pa.table(
+            return pa.table(
                 data=response_json["rows"],
                 names=[e["name"] for e in response_json["foundrySchema"]["fieldSchemaList"]],
             )
-            if return_type == "arrow":
-                return arrow_table
 
-            from foundry_dev_tools._optional.polars import pl
-
-            if getattr(pl, "__fake__", False):
-                msg = "The optional 'polars' package is not installed. Please install it to request polars results."
-                raise ImportError(msg)
-
-            return pl.from_arrow(arrow_table)
         if return_type == "spark":
             from foundry_dev_tools.utils.converter.foundry_spark import (
                 foundry_schema_to_spark_schema,

--- a/libs/foundry-dev-tools/src/foundry_dev_tools/clients/data_proxy.py
+++ b/libs/foundry-dev-tools/src/foundry_dev_tools/clients/data_proxy.py
@@ -217,7 +217,7 @@ class DataProxyClient(APIClient):
         response_json = response.json()
         if return_type == "raw":
             return response_json["foundrySchema"], response_json["rows"]
-        # return_type arrows, pandas and polars use the FakeModule implementation in
+        # return_type arrow, pandas and polars use the FakeModule implementation in
         # their _optional packages. The FakeModule throws an ImportError when trying
         # to access attributes of the module, so no need to explicitly catch ImportError.
         if return_type == "pandas":

--- a/libs/foundry-dev-tools/src/foundry_dev_tools/clients/foundry_sql_server.py
+++ b/libs/foundry-dev-tools/src/foundry_dev_tools/clients/foundry_sql_server.py
@@ -124,6 +124,8 @@ class FoundrySqlServerClient(APIClient):
             ValueError: Only direct read eligible queries can be returned as arrow Table.
 
         """  # noqa: E501
+        assert_in_literal(return_type, SQLReturnType, "return_type")
+
         if return_type == "raw":
             warnings.warn("Falling back to query_foundry_sql_legacy!")
             return self.context.data_proxy.query_foundry_sql_legacy(
@@ -176,7 +178,6 @@ class FoundrySqlServerClient(APIClient):
                 return pl.from_arrow(arrow_table)
             if return_type == "arrow":
                 return arrow_stream_reader.read_all()
-            raise ValueError(f"Unsupported return_type: {return_type}")  # noqa: EM102, TRY003
         except (
             FoundrySqlSerializationFormatNotImplementedError,
             ImportError,

--- a/libs/foundry-dev-tools/src/foundry_dev_tools/foundry_api_client.py
+++ b/libs/foundry-dev-tools/src/foundry_dev_tools/foundry_api_client.py
@@ -943,7 +943,7 @@ class FoundryRestClient:
         branch: api_types.Ref = ...,
         sql_dialect: api_types.SqlDialect = ...,
         timeout: int = ...,
-    ) -> tuple[dict, list[list]] | pd.DataFrame | pa.Table | pyspark.sql.DataFrame: ...
+    ) -> tuple[dict, list[list]] | pd.core.frame.DataFrame | pa.Table | pyspark.sql.DataFrame: ...
 
     def query_foundry_sql_legacy(
         self,
@@ -952,7 +952,7 @@ class FoundryRestClient:
         branch: api_types.Ref = "master",
         sql_dialect: api_types.SqlDialect = "SPARK",
         timeout: int = 600,
-    ) -> tuple[dict, list[list]] | pd.DataFrame | pa.Table | pyspark.sql.DataFrame:
+    ) -> tuple[dict, list[list]] | pd.core.frame.DataFrame | pa.Table | pyspark.sql.DataFrame:
         """Queries the dataproxy query API with spark SQL.
 
         Example:

--- a/libs/foundry-dev-tools/src/foundry_dev_tools/foundry_api_client.py
+++ b/libs/foundry-dev-tools/src/foundry_dev_tools/foundry_api_client.py
@@ -1001,7 +1001,7 @@ class FoundryRestClient:
         branch: api_types.Ref = ...,
         sql_dialect: api_types.SqlDialect = ...,
         timeout: int = ...,
-    ) -> pd.core.frame.DataFrame: ...
+    ) -> pd.DataFrame: ...
 
     @overload
     def query_foundry_sql(
@@ -1051,7 +1051,7 @@ class FoundryRestClient:
         branch: api_types.Ref = ...,
         sql_dialect: api_types.SqlDialect = ...,
         timeout: int = ...,
-    ) -> tuple[dict, list[list]] | pd.core.frame.DataFrame | pl.DataFrame | pa.Table | pyspark.sql.DataFrame: ...
+    ) -> tuple[dict, list[list]] | pd.DataFrame | pl.DataFrame | pa.Table | pyspark.sql.DataFrame: ...
 
     def query_foundry_sql(
         self,
@@ -1060,7 +1060,7 @@ class FoundryRestClient:
         branch: api_types.Ref = "master",
         sql_dialect: api_types.SqlDialect = "SPARK",
         timeout: int = 600,
-    ) -> tuple[dict, list[list]] | pd.core.frame.DataFrame | pl.DataFrame | pa.Table | pyspark.sql.DataFrame:
+    ) -> tuple[dict, list[list]] | pd.DataFrame | pl.DataFrame | pa.Table | pyspark.sql.DataFrame:
         """Queries the Foundry SQL server with spark SQL dialect.
 
         Uses Arrow IPC to communicate with the Foundry SQL Server Endpoint.

--- a/libs/foundry-dev-tools/src/foundry_dev_tools/foundry_api_client.py
+++ b/libs/foundry-dev-tools/src/foundry_dev_tools/foundry_api_client.py
@@ -2,7 +2,7 @@
 
 One of the gaols of this module is to be self-contained so that it can be
 dropped into any python installation with minimal dependency to 'requests'
-Optional dependencies for the SQL functionality to work are pandas and pyarrow.
+Optional dependencies for the SQL functionality to work are pandas, polars and pyarrow.
 
 """
 
@@ -41,6 +41,7 @@ if TYPE_CHECKING:
     from collections.abc import Iterator
 
     import pandas as pd
+    import polars as pl
     import pyarrow as pa
     import pyspark
     import requests
@@ -928,6 +929,16 @@ class FoundryRestClient:
     def query_foundry_sql_legacy(
         self,
         query: str,
+        return_type: Literal["polars"],
+        branch: api_types.Ref = ...,
+        sql_dialect: api_types.SqlDialect = ...,
+        timeout: int = ...,
+    ) -> pl.DataFrame: ...
+
+    @overload
+    def query_foundry_sql_legacy(
+        self,
+        query: str,
         return_type: Literal["raw"],
         branch: api_types.Ref = ...,
         sql_dialect: api_types.SqlDialect = ...,
@@ -942,7 +953,7 @@ class FoundryRestClient:
         branch: api_types.Ref = ...,
         sql_dialect: api_types.SqlDialect = ...,
         timeout: int = ...,
-    ) -> tuple[dict, list[list]] | pd.core.frame.DataFrame | pa.Table | pyspark.sql.DataFrame: ...
+    ) -> tuple[dict, list[list]] | pd.core.frame.DataFrame | pl.DataFrame | pa.Table | pyspark.sql.DataFrame: ...
 
     def query_foundry_sql_legacy(
         self,
@@ -951,7 +962,7 @@ class FoundryRestClient:
         branch: api_types.Ref = "master",
         sql_dialect: api_types.SqlDialect = "SPARK",
         timeout: int = 600,
-    ) -> tuple[dict, list[list]] | pd.core.frame.DataFrame | pa.Table | pyspark.sql.DataFrame:
+    ) -> tuple[dict, list[list]] | pd.core.frame.DataFrame | pl.DataFrame | pa.Table | pyspark.sql.DataFrame:
         """Queries the dataproxy query API with spark SQL.
 
         Example:
@@ -1026,6 +1037,16 @@ class FoundryRestClient:
     def query_foundry_sql(
         self,
         query: str,
+        return_type: Literal["polars"],
+        branch: api_types.Ref = ...,
+        sql_dialect: api_types.SqlDialect = ...,
+        timeout: int = ...,
+    ) -> pl.DataFrame: ...
+
+    @overload
+    def query_foundry_sql(
+        self,
+        query: str,
         return_type: Literal["raw"],
         branch: api_types.Ref = ...,
         sql_dialect: api_types.SqlDialect = ...,
@@ -1040,7 +1061,7 @@ class FoundryRestClient:
         branch: api_types.Ref = ...,
         sql_dialect: api_types.SqlDialect = ...,
         timeout: int = ...,
-    ) -> tuple[dict, list[list]] | pd.core.frame.DataFrame | pa.Table | pyspark.sql.DataFrame: ...
+    ) -> tuple[dict, list[list]] | pd.core.frame.DataFrame | pl.DataFrame | pa.Table | pyspark.sql.DataFrame: ...
 
     def query_foundry_sql(
         self,
@@ -1049,7 +1070,7 @@ class FoundryRestClient:
         branch: api_types.Ref = "master",
         sql_dialect: api_types.SqlDialect = "SPARK",
         timeout: int = 600,
-    ) -> tuple[dict, list[list]] | pd.core.frame.DataFrame | pa.Table | pyspark.sql.DataFrame:
+    ) -> tuple[dict, list[list]] | pd.core.frame.DataFrame | pl.DataFrame | pa.Table | pyspark.sql.DataFrame:
         """Queries the Foundry SQL server with spark SQL dialect.
 
         Uses Arrow IPC to communicate with the Foundry SQL Server Endpoint.

--- a/libs/foundry-dev-tools/src/foundry_dev_tools/foundry_api_client.py
+++ b/libs/foundry-dev-tools/src/foundry_dev_tools/foundry_api_client.py
@@ -929,16 +929,6 @@ class FoundryRestClient:
     def query_foundry_sql_legacy(
         self,
         query: str,
-        return_type: Literal["polars"],
-        branch: api_types.Ref = ...,
-        sql_dialect: api_types.SqlDialect = ...,
-        timeout: int = ...,
-    ) -> pl.DataFrame: ...
-
-    @overload
-    def query_foundry_sql_legacy(
-        self,
-        query: str,
         return_type: Literal["raw"],
         branch: api_types.Ref = ...,
         sql_dialect: api_types.SqlDialect = ...,
@@ -953,7 +943,7 @@ class FoundryRestClient:
         branch: api_types.Ref = ...,
         sql_dialect: api_types.SqlDialect = ...,
         timeout: int = ...,
-    ) -> tuple[dict, list[list]] | pd.core.frame.DataFrame | pl.DataFrame | pa.Table | pyspark.sql.DataFrame: ...
+    ) -> tuple[dict, list[list]] | pd.DataFrame | pa.Table | pyspark.sql.DataFrame: ...
 
     def query_foundry_sql_legacy(
         self,
@@ -962,7 +952,7 @@ class FoundryRestClient:
         branch: api_types.Ref = "master",
         sql_dialect: api_types.SqlDialect = "SPARK",
         timeout: int = 600,
-    ) -> tuple[dict, list[list]] | pd.core.frame.DataFrame | pl.DataFrame | pa.Table | pyspark.sql.DataFrame:
+    ) -> tuple[dict, list[list]] | pd.DataFrame | pa.Table | pyspark.sql.DataFrame:
         """Queries the dataproxy query API with spark SQL.
 
         Example:

--- a/libs/foundry-dev-tools/src/foundry_dev_tools/resources/dataset.py
+++ b/libs/foundry-dev-tools/src/foundry_dev_tools/resources/dataset.py
@@ -697,7 +697,7 @@ class Dataset(resource.Resource):
         return_type: Literal["pandas"],
         sql_dialect: api_types.SqlDialect = ...,
         timeout: int = ...,
-    ) -> pd.core.frame.DataFrame: ...
+    ) -> pd.DataFrame: ...
 
     @overload
     def query_foundry_sql(
@@ -797,12 +797,6 @@ class Dataset(resource.Resource):
 
         Via :py:meth:`foundry_dev_tools.resources.dataset.Dataset.query_foundry_sql`
         """
-        from foundry_dev_tools._optional.polars import pl
-
-        if getattr(pl, "__fake__", False):
-            msg = "The optional 'polars' package is not installed. Please install it to use the 'to_polars' method"
-            raise ImportError(msg)
-
         return self.query_foundry_sql("SELECT *", return_type="polars")
 
     @contextmanager

--- a/libs/foundry-dev-tools/src/foundry_dev_tools/utils/api_types.py
+++ b/libs/foundry-dev-tools/src/foundry_dev_tools/utils/api_types.py
@@ -95,10 +95,11 @@ GroupId = str
 SqlDialect = Literal["ANSI", "SPARK"]
 """The SQL Dialect for Foundry SQL queries."""
 
-SQLReturnType = Literal["pandas", "spark", "arrow", "raw"]
+SQLReturnType = Literal["pandas", "polars", "spark", "arrow", "raw"]
 """The return_types for sql queries.
 
 pandas: :external+pandas:py:class:`pandas.DataFrame`
+polars: :external+polars:py:class:`polars.DataFrame`
 arrow: :external+pyarrow:py:class:`pyarrow.Table`
 spark: :external+spark:py:class:`~pyspark.sql.DataFrame`
 raw: Tuple of (foundry_schema, data) (can only be used in legacy)

--- a/tests/integration/clients/test_foundry_sql_server.py
+++ b/tests/integration/clients/test_foundry_sql_server.py
@@ -1,3 +1,4 @@
+import polars as pl
 import pytest
 
 from foundry_dev_tools.errors.dataset import BranchNotFoundError, DatasetHasNoSchemaError, DatasetNotFoundError
@@ -10,6 +11,16 @@ def test_smoke():
         f"SELECT sepal_width FROM `{TEST_SINGLETON.iris_new.rid}` LIMIT 1",
     )
     assert one_row_one_column.shape == (1, 1)
+
+
+def test_polars_return_type():
+    polars_df = TEST_SINGLETON.ctx.foundry_sql_server.query_foundry_sql(
+        f"SELECT sepal_length FROM `{TEST_SINGLETON.iris_new.rid}` LIMIT 2",
+        return_type="polars",
+    )
+    assert isinstance(polars_df, pl.DataFrame)
+    assert polars_df.height == 2
+    assert polars_df.width == 1
 
 
 def test_exceptions():

--- a/tests/integration/resources/test_dataset.py
+++ b/tests/integration/resources/test_dataset.py
@@ -97,6 +97,10 @@ def test_crud_dataset(spark_session, tmp_path):  # noqa: PLR0915
     ds_polars_branch = TEST_SINGLETON.ctx.get_dataset(ds.rid, branch="polars")
     ds_polars_branch.save_dataframe(polars_df)
     pl_assert_frame_equal(polars_df, ds_polars_branch.to_polars())
+    pl_assert_frame_equal(
+        polars_df,
+        ds_polars_branch.query_foundry_sql("SELECT *", return_type="polars"),
+    )
 
     ds_spark_branch = TEST_SINGLETON.ctx.get_dataset(ds.rid, branch="spark")
     ds_spark_branch.save_dataframe(spark_df)


### PR DESCRIPTION
# Summary

Extend `query_foundry_sql()` in the classes `Dataset`, `FoundryRestClient`, and `FoundrySqlServerClient`  with the return_type polars.

<!-- summary of your changes -->

# Checklist

- [x] You agree with our [CLA](https://gist.githubusercontent.com/emdgroup-admin/16cc45ea4315c2ef29eb9d9afc36fcf5/raw/abb9c91f15278a62b9ac3e66144bcd27fa9485c2/CLA.md)
- [x] Included tests (or is not applicable).
- [x] Updated [documentation](https://emdgroup.github.io/foundry-dev-tools/) (or is not applicable).
- [x] Used [pre-commit hooks](https://emdgroup.github.io/foundry-dev-tools/develop.html#pre-commit-hooks-formatting) to format and lint the code.
