### PR TITLE
feat: add FoundryContext.public_auth for OSDK and platform SDK integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,35 @@ It consists of two parts:
     # Out[2]: (17, 10)
     ```
 
+  - FDT can also act as the auth provider for [foundry-platform-sdk](https://pypi.org/project/foundry-platform-sdk/) and any TPA-specific OSDK package. Install the optional dependency first:
+
+    ```shell
+    pip install 'foundry-dev-tools[public]'
+    ```
+
+    Use the built-in `foundry-platform-sdk` client:
+
+    ```python
+    import pyarrow as pa
+    import polars as pl
+    from foundry_dev_tools import FoundryContext
+
+    ctx = FoundryContext()
+    client = ctx.public_client_v2
+    ds = client.datasets.Dataset.read_table("<dataset-rid>", format="ARROW")
+    df = pl.from_arrow(pa.ipc.open_stream(ds).read_all())
+    ```
+
+    Or pass FDT's auth to any TPA OSDK client:
+
+    ```python
+    from foundry_dev_tools import FoundryContext
+    from my_tpa_sdk import FoundryClient  # your generated OSDK package
+
+    ctx = FoundryContext()
+    client = FoundryClient(auth=ctx.public_auth, hostname=ctx.host.domain)
+    ```
+
 ## Quickstart
 
 With pip:

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog],
 and this project adheres to [Semantic Versioning].
 
+## [2.1.24] - 2026-05-07
+
+## Added
+- add `FoundryContext.public_auth` property returning a `FoundryDevToolsAuth` adapter for use with OSDK and foundry-platform-sdk clients
+
+## Fixed
+- fix misleading error message when `foundry-platform-sdk` is not installed (was suggesting `pip install foundry_sdk`)
+
 ## [2.1.23] - 2026-02-20
 
 ## Added

--- a/docs/examples/api.md
+++ b/docs/examples/api.md
@@ -49,3 +49,40 @@ cached_client = CachedFoundryClient()
 df = cached_client.load_dataset('/path/to/test_dataset', branch='master')
 df.toPandas().to_string()
 ```
+
+## foundry-platform-sdk and OSDK integration
+
+FDT can act as the auth provider for the [foundry-platform-sdk](https://pypi.org/project/foundry-platform-sdk/) and any TPA-specific OSDK package generated from a Foundry third-party application (TPA).
+
+Install the optional dependency first:
+
+```shell
+pip install 'foundry-dev-tools[public]'
+```
+
+### Using the built-in foundry-platform-sdk client
+
+`ctx.public_client_v2` returns a pre-configured `foundry_sdk.v2.FoundryClient`:
+
+```python
+import pyarrow as pa
+import polars as pl
+from foundry_dev_tools import FoundryContext
+
+ctx = FoundryContext()
+client = ctx.public_client_v2
+ds = client.datasets.Dataset.read_table("<dataset-rid>", format="ARROW")
+df = pl.from_arrow(pa.ipc.open_stream(ds).read_all())
+```
+
+### Using a TPA OSDK package
+
+`ctx.public_auth` returns a `FoundryDevToolsAuth` adapter that can be passed directly to any OSDK client:
+
+```python
+from foundry_dev_tools import FoundryContext
+from my_tpa_sdk import FoundryClient  # your generated OSDK package
+
+ctx = FoundryContext()
+client = FoundryClient(auth=ctx.public_auth, hostname=ctx.host.domain)
+```

--- a/libs/foundry-dev-tools/src/foundry_dev_tools/_optional/foundry_platform_sdk.py
+++ b/libs/foundry-dev-tools/src/foundry_dev_tools/_optional/foundry_platform_sdk.py
@@ -8,6 +8,6 @@ try:
 except ImportError:
     from foundry_dev_tools._optional import FakeModule
 
-    foundry_sdk = FakeModule("foundry_sdk")
+    foundry_sdk = FakeModule("foundry-platform-sdk")
 
 __all__ = ["foundry_sdk"]

--- a/libs/foundry-dev-tools/src/foundry_dev_tools/config/context.py
+++ b/libs/foundry-dev-tools/src/foundry_dev_tools/config/context.py
@@ -40,6 +40,7 @@ if TYPE_CHECKING:
     from foundry_dev_tools.config.config_types import Host, Token
     from foundry_dev_tools.config.token_provider import TokenProvider
     from foundry_dev_tools.foundry_api_client import FoundryRestClient
+    from foundry_dev_tools.public_sdk.auth import FoundryDevToolsAuth
     from foundry_dev_tools.utils import api_types
 
 
@@ -192,6 +193,20 @@ class FoundryContext:
 
         return FoundryRestClient(ctx=self)
 
+    @property
+    def public_auth(self) -> FoundryDevToolsAuth:
+        """Returns :py:class:`foundry_dev_tools.public_sdk.auth.FoundryDevToolsAuth`.
+
+        Auth adapter for use with OSDK and foundry-platform-sdk clients.
+
+        Examples:
+            >>> from my_tpa_sdk import FoundryClient
+            >>> client = FoundryClient(auth=ctx.public_auth, hostname=ctx.host.domain)
+        """
+        from foundry_dev_tools.public_sdk.auth import FoundryDevToolsAuth
+
+        return FoundryDevToolsAuth(self)
+
     @cached_property
     def public_client_v2(self) -> FoundrySdkV2Client:
         """Returns :py:class:`foundry_sdk.v2.FoundryClient`.
@@ -208,10 +223,9 @@ class FoundryContext:
             >>> polars_df = pl.from_arrow(pa_df)
         """
         from foundry_dev_tools._optional.foundry_platform_sdk import foundry_sdk
-        from foundry_dev_tools.public_sdk.auth import FoundryDevToolsAuth
 
         return foundry_sdk.v2.FoundryClient(
-            auth=FoundryDevToolsAuth(self),
+            auth=self.public_auth,
             hostname=self.host.domain,
         )
 

--- a/tests/unit/public_sdk/test_auth.py
+++ b/tests/unit/public_sdk/test_auth.py
@@ -26,6 +26,22 @@ def test_foundry_dev_tools_auth_get_token_bridges_context_token(test_context_moc
     assert token.access_token == expected_token
 
 
+def test_public_auth_returns_foundry_dev_tools_auth(test_context_mock):
+    """Verify FoundryContext.public_auth returns a FoundryDevToolsAuth wrapping the context."""
+    auth = test_context_mock.public_auth
+
+    assert isinstance(auth, FoundryDevToolsAuth)
+    assert auth._ctx is test_context_mock
+
+
+def test_public_auth_token_matches_context_token(test_context_mock):
+    """Verify public_auth reflects the current context token."""
+    expected_token = "public-auth-token-789"  # noqa: S105
+    test_context_mock.token_provider._jwt = expected_token
+
+    assert test_context_mock.public_auth.get_token().access_token == expected_token
+
+
 def test_public_client_v2_uses_foundry_dev_tools_auth(test_context_mock):
     """Verify FoundryContext.public_client_v2 creates FoundryClient with FoundryDevToolsAuth."""
     from foundry_sdk.v2 import FoundryClient


### PR DESCRIPTION
## Summary

- Adds `ctx.public_auth` property to `FoundryContext`, returning a `FoundryDevToolsAuth` adapter that implements the `foundry_sdk.Auth` interface
- Simplifies `ctx.public_client_v2` to delegate to `self.public_auth` instead of duplicating the import and instantiation
- Fixes the error message shown when `foundry-platform-sdk` is not installed — it previously suggested `pip install foundry_sdk` (wrong package name); now correctly says `foundry-platform-sdk`

## Motivation

### Previously

Users with TPA-specific OSDK packages had to manually import and wire up `FoundryDevToolsAuth` themselves, and know to pass `ctx.host.domain` for the hostname:

```python
from foundry_dev_tools import FoundryContext
from foundry_dev_tools.public_sdk.auth import FoundryDevToolsAuth

ctx = FoundryContext()
return FoundryClient(auth=FoundryDevToolsAuth(ctx), hostname=ctx.host.domain)
```

### Now

```python
from foundry_dev_tools import FoundryContext

ctx = FoundryContext()
return FoundryClient(auth=ctx.public_auth, hostname=ctx.host.domain)
```

`ctx.public_auth` works for any client sharing the `foundry_sdk.Auth` interface: TPA OSDK packages, `foundry_sdk.v2.FoundryClient`, and the Foundry Platform SDK.


## Notes
- We can not directly construct/return an OSDK compatible client out of fdt, since the module/namespace is different for each OSDK based on the TPA name. 

## Test plan
- [x] `pdm run unit` — 127 tests pass
- [x] `ctx.public_auth` returns `FoundryDevToolsAuth` when `foundry-platform-sdk` is installed
- [x] Without `foundry-platform-sdk`: accessing `ctx.public_auth` raises `ImportError: Missing optional dependency 'foundry-platform-sdk'`


## Discussion
- [x] Do we keep the property name `public_auth`? Or rather something like `public_client_auth`? 